### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/pr_reminder.yml
+++ b/.github/workflows/pr_reminder.yml
@@ -4,6 +4,9 @@ on:
     types: [opened]
 jobs:
   pr_reminder:
+    permissions:
+      contents: read
+      issues: write
     runs-on: ubuntu-latest
     steps:
       - name: Remind to run full CI on PR


### PR DESCRIPTION
Potential fix for [https://github.com/microsoft/setu/security/code-scanning/1](https://github.com/microsoft/setu/security/code-scanning/1)

To fix the issue, add a `permissions` block specifying the minimum permissions necessary for the job. In this case, the script only needs to write issue comments, so set:
- `contents: read` (standard default)
- `issues: write` (to allow commenting)
This block should be placed under the job `pr_reminder:` (preferred for per-job scope), before `runs-on`. Only change this file; do not alter the workflow logic.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
