### PR TITLE
Add client-initiated shard deregistration with deferred cleanup

### DIFF
--- a/csrc/setu/client/Client.h
+++ b/csrc/setu/client/Client.h
@@ -73,6 +73,10 @@ class Client {
   [[nodiscard]] std::vector<TensorShardRefPtr> GetShards() const;
 
  private:
+  static constexpr std::int32_t kDeregisterTimeoutMs = 300000;
+
+  [[nodiscard]] bool DeregisterShards();
+
   // Zmq context and sockets
   ZmqContextPtr zmq_context_;
   ZmqSocketPtr request_socket_;

--- a/csrc/setu/commons/enums/Enums.h
+++ b/csrc/setu/commons/enums/Enums.h
@@ -29,7 +29,8 @@ enum class ErrorCode : std::uint32_t {
   kTimeout = 2,
   kInternalError = 3,
   kTensorNotFound = 4,
-  kTensorNotAllocated = 5
+  kTensorNotAllocated = 5,
+  kTensorDeregistered = 6
 };
 //==============================================================================
 }  // namespace setu::commons::enums
@@ -82,6 +83,9 @@ struct std::formatter<setu::commons::enums::ErrorCode>
         break;
       case setu::commons::enums::ErrorCode::kTensorNotAllocated:
         name = "TENSOR_NOT_ALLOCATED";
+        break;
+      case setu::commons::enums::ErrorCode::kTensorDeregistered:
+        name = "TENSOR_DEREGISTERED";
         break;
     }
     return std::formatter<std::string_view>::format(name, ctx);

--- a/csrc/setu/commons/utils/PendingOperations.h
+++ b/csrc/setu/commons/utils/PendingOperations.h
@@ -19,107 +19,346 @@
 #include "commons/BoostCommon.h"
 #include "commons/StdCommon.h"
 //==============================================================================
-#include "commons/Types.h"
+#include "commons/Logging.h"
 //==============================================================================
 namespace setu::commons::utils {
 //==============================================================================
 
-enum class AddWaiterResult : std::uint8_t {
-  kWaiterAdded,
-  kAlreadyComplete,
-  kNotRegistered
-};
-
-/// @brief Tracks pending async operations with registration, waiting, and
-/// completion.
+/// @brief Dependency tracker: waiters are released when all their blockers
+/// resolve.
 ///
-/// Operations are registered via RegisterOperation (refcounted — multiple
-/// registrations for the same key are allowed). Clients wait via AddWaiter.
-/// When the operation completes, MarkComplete + DrainWaiters serves existing
-/// waiters. Late waiters (arriving after completion) get kAlreadyComplete from
-/// AddWaiter, which drains one completion. The key is fully cleaned up once all
-/// registrations have been drained.
+/// ## Components
 ///
-/// @tparam KeyType The key type (e.g., CopyOperationId, ShardId).
-/// @tparam Hash The hash function for KeyType (defaults to boost::hash).
-template <typename KeyType, typename Hash = boost::hash<KeyType>>
+/// - **Blocker**: something that must finish (e.g., a copy operation ID).
+///   Resolved by calling Resolve(blocker_id).
+/// - **Waiter**: something waiting for one or more blockers to finish
+///   (e.g., a client identity). Added via AddWaiter(waiter_id, {blockers}).
+///   Released (returned from Resolve) when its last remaining blocker
+///   resolves.
+/// - **Payload** (optional): data associated with a waiter. When provided,
+///   Resolve returns payloads instead of waiter IDs.
+///
+/// ## Expressivity
+///
+/// The relationship is fully M:N. Any number of waiters can depend on any
+/// subset of blockers, and blockers can be shared across waiters. A waiter
+/// is released only when ALL of its blockers have been resolved.
+///
+/// Resolve is one-shot: calling Resolve(X) twice returns results only on
+/// the first call. Dependencies are declared at AddWaiter time and cannot
+/// be modified afterward.
+///
+/// ## Lost wakeup handling
+///
+/// If AddWaiter is always called before Resolve, no special handling is
+/// needed — the blocker is tracked implicitly via the reverse index.
+///
+/// A lost wakeup occurs when a blocker finishes before the waiter
+/// registers. Resolve already fired and won't be called again, so the
+/// waiter would be stuck forever.
+///
+/// RegisterBlocker prevents this. It tells PendingOperations that a
+/// blocker exists and might finish early. When Resolve is called on a
+/// registered blocker, a tombstone is recorded — a marker that says "this
+/// blocker already finished." When a waiter later calls AddWaiter and all
+/// its blockers have tombstones, the result is returned immediately.
+///
+/// RegisterBlocker is refcounted: calling it N times for the same key
+/// allows N late AddWaiter calls to be served. Each one decrements the
+/// refcount, and the tombstone is cleaned up when it hits zero.
+///
+/// RemoveBlocker force-clears a blocker's registration, tombstone, and
+/// reverse index. Use it when the blocker is being torn down and no more
+/// waiters will arrive for it.
+///
+/// **Memory contract**: every registered blocker must eventually be
+/// consumed by a late AddWaiter or explicitly cleaned up via
+/// RemoveBlocker. Otherwise the tombstone leaks.
+///
+/// ## Examples
+///
+/// ### Without payload — Resolve returns waiter IDs
+/// @code
+///   PendingOperations<std::string, std::int32_t> pending;
+///
+///   pending.AddWaiter("client_1", {42});
+///   pending.AddWaiter("client_2", {42});
+///
+///   auto released = pending.Resolve(42);
+///   // released == {"client_1", "client_2"}
+/// @endcode
+///
+/// ### With payload — Resolve returns payloads
+/// @code
+///   PendingOperations<std::string, std::string, MyRequest> pending;
+///
+///   pending.AddWaiter("req_1", {"copy_A", "copy_B"}, MyRequest{...});
+///
+///   pending.Resolve("copy_A");  // returns {} — still waiting on copy_B
+///   auto r = pending.Resolve("copy_B");
+///   // r == {MyRequest{...}} — all blockers done, payload returned
+/// @endcode
+///
+/// ### Lost wakeup handling
+/// @code
+///   PendingOperations<std::string, std::int32_t> pending;
+///
+///   pending.RegisterBlocker(7);
+///   pending.Resolve(7);  // no waiters yet — tombstone is kept
+///
+///   auto r = pending.AddWaiter("late_client", {7});
+///   // r == "late_client" — returned immediately, tombstone consumed
+/// @endcode
+///
+/// @tparam WaiterId      Key type identifying each waiter.
+/// @tparam BlockerId     Key type identifying each blocker.
+/// @tparam WaiterPayload Optional payload type stored with each waiter.
+///                        When void, the WaiterId itself serves as the result.
+/// @tparam WaiterHash    Hash function for WaiterId.
+/// @tparam BlockerHash   Hash function for BlockerId.
+template <typename WaiterId, typename BlockerId, typename WaiterPayload = void,
+          typename WaiterHash = boost::hash<WaiterId>,
+          typename BlockerHash = boost::hash<BlockerId>>
 class PendingOperations {
+  static constexpr bool kHasPayload = !std::is_void_v<WaiterPayload>;
+  using StoredPayload =
+      std::conditional_t<kHasPayload, WaiterPayload, std::monostate>;
+  using ResultType = std::conditional_t<kHasPayload, WaiterPayload, WaiterId>;
+
+  struct WaiterEntry {
+    std::set<BlockerId> blockers;
+    [[no_unique_address]] StoredPayload payload{};
+  };
+
  public:
-  /// @brief Register an operation. Can be called multiple times for the same
-  /// key; each call increments the expected number of waiters.
-  /// @param key [in] The operation key to register.
-  void RegisterOperation(const KeyType& key /*[in]*/) {
-    registration_count_[key]++;
+  // --- Blocker lifecycle ---
+
+  /// @brief Register a blocker for lost wakeup handling.
+  ///
+  /// Only needed when Resolve may be called before AddWaiter. If the
+  /// caller guarantees AddWaiter always precedes Resolve, registration
+  /// is unnecessary.
+  ///
+  /// When a registered blocker is resolved, a tombstone is kept so that
+  /// a subsequent AddWaiter returns immediately instead of waiting
+  /// forever.
+  ///
+  /// Refcounted: calling RegisterBlocker(X) N times allows N late
+  /// AddWaiter calls to be served before the tombstone is cleaned up.
+  ///
+  /// Every registration must eventually be consumed by a late AddWaiter
+  /// or cleaned up via RemoveBlocker. Otherwise the tombstone leaks.
+  ///
+  /// @param key [in] The blocker key to register.
+  void RegisterBlocker(const BlockerId& key /*[in]*/) { registered_[key]++; }
+
+  /// @brief Check whether a blocker key is registered (refcount > 0).
+  ///
+  /// @param key [in] The blocker key to check.
+  /// @return True if the key has been registered and refcount > 0.
+  [[nodiscard]] bool IsBlockerRegistered(const BlockerId& key /*[in]*/) const {
+    return registered_.contains(key);
   }
 
-  /// @brief Mark the operation as complete. Future AddWaiter calls for this
-  /// key will return kAlreadyComplete.
-  /// @param key [in] The operation key to mark complete.
-  void MarkComplete(const KeyType& key /*[in]*/) { completed_.insert(key); }
-
-  /// @brief Add a waiter for the given key.
+  /// @brief Remove a blocker: erases registration, resolved tombstone, and
+  /// reverse-index entry.
   ///
-  /// If the operation is already complete, drains one completion (decrements
-  /// the registration count) and returns kAlreadyComplete. If the key was
-  /// never registered, returns kNotRegistered. Otherwise, queues the waiter.
+  /// Does NOT release waiters — use Resolve for that.
   ///
-  /// @param key [in] The operation key to wait on.
-  /// @param identity [in] The client identity to register.
-  /// @return The result indicating what action was taken.
-  [[nodiscard]] AddWaiterResult AddWaiter(const KeyType& key /*[in]*/,
-                                          const Identity& identity /*[in]*/) {
-    if (completed_.contains(key)) {
-      DecrementRegistrations(key, 1);
-      return AddWaiterResult::kAlreadyComplete;
-    }
-    if (!registration_count_.contains(key)) {
-      return AddWaiterResult::kNotRegistered;
-    }
-    waiters_[key].push_back(identity);
-    return AddWaiterResult::kWaiterAdded;
+  /// @param key [in] The blocker key to remove.
+  void RemoveBlocker(const BlockerId& key /*[in]*/) {
+    registered_.erase(key);
+    resolved_.erase(key);
+    blocker_to_waiters_.erase(key);
   }
 
-  /// @brief Retrieve and remove all waiters for the given key. Each drained
-  /// waiter decrements the registration count.
-  /// @param key [in] The operation key whose waiters to drain.
-  /// @return Vector of waiting client identities. Empty if no waiters.
-  [[nodiscard]] std::vector<Identity> DrainWaiters(
-      const KeyType& key /*[in]*/) {
-    auto it = waiters_.find(key);
+  // --- Waiter lifecycle ---
+
+  /// @brief Add a waiter blocked by a set of blocker keys (void payload).
+  ///
+  /// If all blockers are already resolved (tombstoned), returns the WaiterId
+  /// immediately (late arrival) and decrements registration refcounts.
+  /// Otherwise, stores the waiter internally.
+  ///
+  /// @param waiter_id [in] Unique identifier for this waiter.
+  /// @param blockers  [in] The set of blocker keys this waiter depends on.
+  /// @return The WaiterId if all blockers are already resolved; std::nullopt
+  ///         if the waiter was stored.
+  [[nodiscard]] std::optional<ResultType> AddWaiter(
+      WaiterId waiter_id /*[in]*/, std::set<BlockerId> blockers /*[in]*/)
+    requires(!kHasPayload)
+  {
+    return AddWaiterImpl(std::move(waiter_id), std::move(blockers),
+                         std::monostate{});
+  }
+
+  /// @brief Add a waiter blocked by a set of blocker keys (with payload).
+  ///
+  /// If all blockers are already resolved (tombstoned), returns the payload
+  /// immediately (late arrival) and decrements registration refcounts.
+  /// Otherwise, stores the waiter internally.
+  ///
+  /// @param waiter_id [in] Unique identifier for this waiter.
+  /// @param blockers  [in] The set of blocker keys this waiter depends on.
+  /// @param payload   [in] The data to associate with this waiter.
+  /// @return The payload if all blockers are already resolved; std::nullopt
+  ///         if the waiter was stored.
+  template <typename P = StoredPayload>
+    requires(kHasPayload)
+  [[nodiscard]] std::optional<ResultType> AddWaiter(
+      WaiterId waiter_id /*[in]*/, std::set<BlockerId> blockers /*[in]*/,
+      P payload /*[in]*/) {
+    return AddWaiterImpl(std::move(waiter_id), std::move(blockers),
+                         StoredPayload{std::move(payload)});
+  }
+
+  /// @brief Remove a waiter and clean up its blocker references.
+  ///
+  /// @param waiter_id [in] The waiter to remove.
+  void RemoveWaiter(const WaiterId& waiter_id /*[in]*/) {
+    auto it = waiters_.find(waiter_id);
     if (it == waiters_.end()) {
-      return {};
+      return;
     }
-    std::vector<Identity> result = std::move(it->second);
+
+    for (const auto& key : it->second.blockers) {
+      auto rev_it = blocker_to_waiters_.find(key);
+      if (rev_it != blocker_to_waiters_.end()) {
+        rev_it->second.erase(waiter_id);
+        if (rev_it->second.empty()) {
+          blocker_to_waiters_.erase(rev_it);
+        }
+      }
+    }
+
     waiters_.erase(it);
-    DecrementRegistrations(key, result.size());
-    return result;
   }
 
-  /// @brief Check whether any waiters exist for the given key.
-  /// @param key [in] The operation key to check.
-  /// @return True if at least one waiter is registered.
-  [[nodiscard]] bool HasWaiters(const KeyType& key /*[in]*/) const {
-    return waiters_.contains(key);
+  // --- Resolution ---
+
+  /// @brief A blocker has been resolved.
+  ///
+  /// Removes it from all waiters' blocker sets. Returns results of waiters
+  /// now fully unblocked. Also records as tombstone if the blocker was
+  /// registered (for late-arrival support).
+  ///
+  /// @param key [in] The blocker key that has been resolved.
+  /// @return Vector of WaiterIds (void payload) or WaiterPayloads (non-void)
+  ///         for waiters now fully unblocked.
+  [[nodiscard]] std::vector<ResultType> Resolve(const BlockerId& key /*[in]*/) {
+    // Record tombstone only if this blocker was registered (for late-arrival)
+    if (registered_.contains(key)) {
+      resolved_.insert(key);
+    }
+
+    std::vector<ResultType> unblocked;
+
+    auto idx_it = blocker_to_waiters_.find(key);
+    if (idx_it == blocker_to_waiters_.end()) {
+      return unblocked;
+    }
+
+    // Move out the set of affected waiter IDs and erase the index entry
+    auto waiter_ids = std::move(idx_it->second);
+    blocker_to_waiters_.erase(idx_it);
+
+    for (const auto& waiter_id : waiter_ids) {
+      auto w_it = waiters_.find(waiter_id);
+      if (w_it == waiters_.end()) {
+        continue;
+      }
+
+      w_it->second.blockers.erase(key);
+
+      if (w_it->second.blockers.empty()) {
+        if constexpr (kHasPayload) {
+          unblocked.push_back(std::move(w_it->second.payload));
+        } else {
+          unblocked.push_back(waiter_id);
+        }
+        waiters_.erase(w_it);
+      }
+    }
+
+    return unblocked;
   }
 
  private:
-  void DecrementRegistrations(const KeyType& key /*[in]*/,
-                              std::size_t count /*[in]*/) {
-    auto it = registration_count_.find(key);
-    if (it == registration_count_.end()) {
+  [[nodiscard]] std::optional<ResultType> AddWaiterImpl(
+      WaiterId waiter_id /*[in]*/, std::set<BlockerId> blockers /*[in]*/,
+      StoredPayload payload /*[in]*/) {
+    ASSERT_VALID_ARGUMENTS(!blockers.empty(),
+                           "PendingOperations::AddWaiter requires at least one "
+                           "blocker key");
+
+    // Check if all blockers are already resolved (tombstoned)
+    bool all_resolved = true;
+    for (const auto& key : blockers) {
+      if (!resolved_.contains(key)) {
+        all_resolved = false;
+        break;
+      }
+    }
+
+    if (all_resolved) {
+      // Late arrival: all blockers already resolved — return immediately
+      for (const auto& key : blockers) {
+        DecrementRegistration(key);
+      }
+      if constexpr (kHasPayload) {
+        return std::move(payload);
+      } else {
+        return std::move(waiter_id);
+      }
+    }
+
+    // Build reverse index for unresolved blockers
+    for (const auto& key : blockers) {
+      if (!resolved_.contains(key)) {
+        blocker_to_waiters_[key].insert(waiter_id);
+      }
+    }
+
+    // Remove already-resolved blockers from the waiter's set
+    std::erase_if(blockers, [this](const BlockerId& key) {
+      return resolved_.contains(key);
+    });
+
+    waiters_.emplace(std::move(waiter_id),
+                     WaiterEntry{std::move(blockers), std::move(payload)});
+    return std::nullopt;
+  }
+
+  /// @brief Decrement registration refcount for a blocker key.
+  ///
+  /// Called during late-arrival AddWaiter. When refcount hits 0, erases
+  /// both the registration and the resolved tombstone.
+  void DecrementRegistration(const BlockerId& key /*[in]*/) {
+    auto it = registered_.find(key);
+    if (it == registered_.end()) {
       return;
     }
-    if (it->second <= count) {
-      registration_count_.erase(it);
-      completed_.erase(key);
+    if (it->second <= 1) {
+      registered_.erase(it);
+      resolved_.erase(key);
     } else {
-      it->second -= count;
+      it->second--;
     }
   }
 
-  std::unordered_map<KeyType, std::size_t, Hash> registration_count_;
-  std::unordered_set<KeyType, Hash> completed_;
-  std::unordered_map<KeyType, std::vector<Identity>, Hash> waiters_;
+  /// Forward map: waiter ID → waiter state (blocker set + optional payload)
+  std::unordered_map<WaiterId, WaiterEntry, WaiterHash> waiters_;
+
+  /// Reverse index: blocker key → set of waiter IDs blocked by that key
+  std::unordered_map<BlockerId, std::set<WaiterId>, BlockerHash>
+      blocker_to_waiters_;
+
+  /// Tombstones: blocker keys that have been resolved (for late-arrival).
+  /// Only populated for registered blockers.
+  std::unordered_set<BlockerId, BlockerHash> resolved_;
+
+  /// Registration refcounts (controls late-arrival tombstone lifetime)
+  std::unordered_map<BlockerId, std::size_t, BlockerHash> registered_;
 };
 
 //==============================================================================

--- a/csrc/setu/messaging/DeregisterShardsRequest.cpp
+++ b/csrc/setu/messaging/DeregisterShardsRequest.cpp
@@ -1,0 +1,44 @@
+//==============================================================================
+// Copyright (c) 2025 Vajra Team; Georgia Institute of Technology; Microsoft
+// Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//==============================================================================
+#include "messaging/DeregisterShardsRequest.h"
+//==============================================================================
+namespace setu::commons::messages {
+//==============================================================================
+using setu::commons::utils::BinaryBuffer;
+using setu::commons::utils::BinaryRange;
+using setu::commons::utils::BinaryReader;
+using setu::commons::utils::BinaryWriter;
+//==============================================================================
+
+void DeregisterShardsRequest::Serialize(BinaryBuffer& buffer) const {
+  BinaryWriter writer(buffer);
+  writer.WriteFields(request_id, shards_by_tensor);
+}
+
+DeregisterShardsRequest DeregisterShardsRequest::Deserialize(
+    const BinaryRange& range) {
+  BinaryReader reader(range);
+  auto [request_id_val, shards_by_tensor_val] =
+      reader.ReadFields<RequestId,
+                        std::unordered_map<TensorName, std::vector<ShardId>>>();
+  return DeregisterShardsRequest(request_id_val,
+                                 std::move(shards_by_tensor_val));
+}
+
+//==============================================================================
+}  // namespace setu::commons::messages
+//==============================================================================

--- a/csrc/setu/messaging/DeregisterShardsRequest.h
+++ b/csrc/setu/messaging/DeregisterShardsRequest.h
@@ -1,0 +1,77 @@
+//==============================================================================
+// Copyright (c) 2025 Vajra Team; Georgia Institute of Technology; Microsoft
+// Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//==============================================================================
+#pragma once
+//==============================================================================
+#include "commons/StdCommon.h"
+//==============================================================================
+#include "commons/Types.h"
+#include "commons/utils/Serialization.h"
+#include "messaging/BaseRequest.h"
+//==============================================================================
+namespace setu::commons::messages {
+//==============================================================================
+using setu::commons::ShardId;
+using setu::commons::TensorName;
+using setu::commons::utils::BinaryBuffer;
+using setu::commons::utils::BinaryRange;
+//==============================================================================
+
+/// @brief Request to deregister tensor shards on disconnect.
+/// Sent from Client → NodeAgent and forwarded NodeAgent → Coordinator.
+struct DeregisterShardsRequest : public BaseRequest {
+  /// @brief Constructs a request with auto-generated request ID.
+  explicit DeregisterShardsRequest(
+      std::unordered_map<TensorName, std::vector<ShardId>>
+          shards_by_tensor_param)
+      : BaseRequest(), shards_by_tensor(std::move(shards_by_tensor_param)) {
+    ASSERT_VALID_ARGUMENTS(!shards_by_tensor.empty(),
+                           "Shards map cannot be empty");
+  }
+
+  /// @brief Constructs a request with explicit request ID (for
+  /// deserialization).
+  DeregisterShardsRequest(RequestId request_id_param,
+                          std::unordered_map<TensorName, std::vector<ShardId>>
+                              shards_by_tensor_param)
+      : BaseRequest(request_id_param),
+        shards_by_tensor(std::move(shards_by_tensor_param)) {
+    ASSERT_VALID_ARGUMENTS(!shards_by_tensor.empty(),
+                           "Shards map cannot be empty");
+  }
+
+  [[nodiscard]] std::string ToString() const {
+    std::size_t total_shards = 0;
+    for (const auto& [name, ids] : shards_by_tensor) {
+      total_shards += ids.size();
+    }
+    return std::format(
+        "DeregisterShardsRequest(request_id={}, num_tensors={}, "
+        "total_shards={})",
+        request_id, shards_by_tensor.size(), total_shards);
+  }
+
+  void Serialize(BinaryBuffer& buffer) const;
+
+  static DeregisterShardsRequest Deserialize(const BinaryRange& range);
+
+  const std::unordered_map<TensorName, std::vector<ShardId>> shards_by_tensor;
+};
+using DeregisterShardsRequestPtr = std::shared_ptr<DeregisterShardsRequest>;
+
+//==============================================================================
+}  // namespace setu::commons::messages
+//==============================================================================

--- a/csrc/setu/messaging/DeregisterShardsResponse.cpp
+++ b/csrc/setu/messaging/DeregisterShardsResponse.cpp
@@ -1,0 +1,42 @@
+//==============================================================================
+// Copyright (c) 2025 Vajra Team; Georgia Institute of Technology; Microsoft
+// Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//==============================================================================
+#include "messaging/DeregisterShardsResponse.h"
+//==============================================================================
+namespace setu::commons::messages {
+//==============================================================================
+using setu::commons::utils::BinaryBuffer;
+using setu::commons::utils::BinaryRange;
+using setu::commons::utils::BinaryReader;
+using setu::commons::utils::BinaryWriter;
+//==============================================================================
+
+void DeregisterShardsResponse::Serialize(BinaryBuffer& buffer) const {
+  BinaryWriter writer(buffer);
+  writer.WriteFields(request_id, error_code);
+}
+
+DeregisterShardsResponse DeregisterShardsResponse::Deserialize(
+    const BinaryRange& range) {
+  BinaryReader reader(range);
+  auto [request_id_val, error_code_val] =
+      reader.ReadFields<RequestId, ErrorCode>();
+  return DeregisterShardsResponse(request_id_val, error_code_val);
+}
+
+//==============================================================================
+}  // namespace setu::commons::messages
+//==============================================================================

--- a/csrc/setu/messaging/DeregisterShardsResponse.h
+++ b/csrc/setu/messaging/DeregisterShardsResponse.h
@@ -1,0 +1,53 @@
+//==============================================================================
+// Copyright (c) 2025 Vajra Team; Georgia Institute of Technology; Microsoft
+// Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//==============================================================================
+#pragma once
+//==============================================================================
+#include "commons/StdCommon.h"
+//==============================================================================
+#include "commons/Types.h"
+#include "commons/utils/Serialization.h"
+#include "messaging/BaseResponse.h"
+//==============================================================================
+namespace setu::commons::messages {
+//==============================================================================
+using setu::commons::RequestId;
+using setu::commons::utils::BinaryBuffer;
+using setu::commons::utils::BinaryRange;
+//==============================================================================
+
+/// @brief Response to a DeregisterShardsRequest.
+/// Used for both Coordinator → NodeAgent and NodeAgent → Client.
+struct DeregisterShardsResponse : public BaseResponse {
+  explicit DeregisterShardsResponse(
+      RequestId request_id_param,
+      ErrorCode error_code_param = ErrorCode::kSuccess)
+      : BaseResponse(request_id_param, error_code_param) {}
+
+  [[nodiscard]] std::string ToString() const {
+    return std::format("DeregisterShardsResponse(request_id={}, error_code={})",
+                       request_id, error_code);
+  }
+
+  void Serialize(BinaryBuffer& buffer) const;
+
+  static DeregisterShardsResponse Deserialize(const BinaryRange& range);
+};
+using DeregisterShardsResponsePtr = std::shared_ptr<DeregisterShardsResponse>;
+
+//==============================================================================
+}  // namespace setu::commons::messages
+//==============================================================================

--- a/csrc/setu/messaging/Messages.h
+++ b/csrc/setu/messaging/Messages.h
@@ -24,6 +24,8 @@
 #include "messaging/BaseResponse.h"
 #include "messaging/CopyOperationFinishedRequest.h"
 #include "messaging/CopyOperationFinishedResponse.h"
+#include "messaging/DeregisterShardsRequest.h"
+#include "messaging/DeregisterShardsResponse.h"
 #include "messaging/ExecuteProgramRequest.h"
 #include "messaging/ExecuteProgramResponse.h"
 #include "messaging/ExecuteRequest.h"
@@ -51,19 +53,21 @@ namespace setu::commons::messages {
 using ClientRequest =
     std::variant<RegisterTensorShardRequest, SubmitCopyRequest,
                  SubmitPullRequest, WaitForCopyRequest, GetTensorHandleRequest,
-                 WaitForShardAllocationRequest, GetTensorSelectionRequest>;
+                 WaitForShardAllocationRequest, GetTensorSelectionRequest,
+                 DeregisterShardsRequest>;
 
 /// @brief Requests from NodeAgent to Coordinator.
 using NodeAgentRequest =
     std::variant<RegisterTensorShardRequest, SubmitCopyRequest,
-                 SubmitPullRequest, ExecuteResponse, GetTensorSpecRequest>;
+                 SubmitPullRequest, ExecuteResponse, GetTensorSpecRequest,
+                 DeregisterShardsRequest>;
 
 /// @brief All messages from Coordinator to NodeAgent
 using CoordinatorMessage =
     std::variant<AllocateTensorRequest, CopyOperationFinishedRequest,
                  ExecuteRequest, RegisterTensorShardCoordinatorResponse,
-                 SubmitCopyResponse, WaitForCopyResponse,
-                 GetTensorSpecResponse>;
+                 SubmitCopyResponse, WaitForCopyResponse, GetTensorSpecResponse,
+                 DeregisterShardsResponse>;
 
 using Request =
     std::variant<RegisterTensorShardRequest, SubmitCopyRequest,

--- a/csrc/setu/metastore/MetaStore.cpp
+++ b/csrc/setu/metastore/MetaStore.cpp
@@ -202,5 +202,68 @@ const TensorSpec* MetaStore::GetTensorSpec(
   return nullptr;
 }
 //==============================================================================
+bool MetaStore::IsTensorDeregistered(const TensorName& tensor_name) const {
+  std::lock_guard<std::recursive_mutex> lock(mutex_);
+
+  auto it = registered_shards_data_.find(tensor_name);
+  if (it == registered_shards_data_.end()) {
+    return false;
+  }
+  return it->second.has_deregistered_shards;
+}
+void MetaStore::MarkTensorDeregistered(const TensorName& tensor_name) {
+  std::lock_guard<std::recursive_mutex> lock(mutex_);
+
+  auto it = registered_shards_data_.find(tensor_name);
+  if (it == registered_shards_data_.end()) {
+    LOG_WARNING("MarkTensorDeregistered: tensor '{}' not found", tensor_name);
+    return;
+  }
+  it->second.has_deregistered_shards = true;
+}
+//==============================================================================
+void MetaStore::DeregisterShards(
+    const std::unordered_map<TensorName, std::vector<ShardId>>&
+        shards_by_tensor) {
+  std::lock_guard<std::recursive_mutex> lock(mutex_);
+
+  for (const auto& [tensor_name, shard_ids] : shards_by_tensor) {
+    auto it = registered_shards_data_.find(tensor_name);
+    if (it == registered_shards_data_.end()) {
+      LOG_WARNING("DeregisterShards: tensor '{}' not found", tensor_name);
+      continue;
+    }
+    auto& data = it->second;
+    data.has_deregistered_shards = true;
+
+    for (const auto& shard_id : shard_ids) {
+      auto shard_it = data.shards.find(shard_id);
+      if (shard_it == data.shards.end()) {
+        LOG_WARNING("DeregisterShards: shard {} not found in tensor '{}'",
+                    shard_id, tensor_name);
+        continue;
+      }
+
+      std::size_t shard_num_elements = shard_it->second->spec.GetNumElements();
+      data.registered_size -= shard_num_elements;
+      data.shards.erase(shard_it);
+
+      LOG_DEBUG("Deregistered shard {} from tensor '{}', registered={}/{}",
+                shard_id, tensor_name, data.registered_size,
+                data.expected_size);
+    }
+
+    // Invalidate cached TensorMetadata for this tensor
+    tensor_metadata_cache_.erase(tensor_name);
+
+    // If no shards remain, clean up the tensor entirely
+    if (data.shards.empty()) {
+      LOG_DEBUG("All shards removed for tensor '{}', cleaning up", tensor_name);
+      registered_shards_data_.erase(it);
+      tensor_spec_cache_.erase(tensor_name);
+    }
+  }
+}
+//==============================================================================
 }  // namespace setu::metastore
 //==============================================================================

--- a/csrc/test/native/PendingOperationsTest.cpp
+++ b/csrc/test/native/PendingOperationsTest.cpp
@@ -1,0 +1,381 @@
+//==============================================================================
+// Copyright (c) 2025 Vajra Team; Georgia Institute of Technology; Microsoft
+// Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//==============================================================================
+#include <gtest/gtest.h>
+//==============================================================================
+#include "commons/StdCommon.h"
+#include "commons/utils/PendingOperations.h"
+//==============================================================================
+namespace setu::test::native {
+//==============================================================================
+namespace {
+//==============================================================================
+
+using setu::commons::utils::PendingOperations;
+
+// Void-payload type: WaiterId=string, BlockerId=int32_t
+using VoidPending = PendingOperations<std::string, std::int32_t>;
+
+// Payload type: WaiterId=string, BlockerId=string, Payload=int32_t
+using PayloadPending =
+    PendingOperations<std::string, std::string, std::int32_t>;
+
+//==============================================================================
+// N:1 Pattern Tests (many waiters on one blocker)
+//==============================================================================
+
+TEST(PendingOperationsTest, N1_RegisterAddResolve_ReturnsAllWaiters) {
+  VoidPending pending;
+  pending.RegisterBlocker(1);
+
+  auto r1 = pending.AddWaiter("waiter_a", {1});
+  auto r2 = pending.AddWaiter("waiter_b", {1});
+  auto r3 = pending.AddWaiter("waiter_c", {1});
+
+  EXPECT_FALSE(r1.has_value()) << "Waiter should be stored, not returned";
+  EXPECT_FALSE(r2.has_value());
+  EXPECT_FALSE(r3.has_value());
+
+  auto unblocked = pending.Resolve(1);
+  ASSERT_EQ(unblocked.size(), 3u);
+
+  // Sort for deterministic comparison
+  std::sort(unblocked.begin(), unblocked.end());
+  EXPECT_EQ(unblocked[0], "waiter_a");
+  EXPECT_EQ(unblocked[1], "waiter_b");
+  EXPECT_EQ(unblocked[2], "waiter_c");
+}
+
+TEST(PendingOperationsTest, N1_ResolveWithNoWaiters_ReturnsEmpty) {
+  VoidPending pending;
+  pending.RegisterBlocker(1);
+
+  auto unblocked = pending.Resolve(1);
+  EXPECT_TRUE(unblocked.empty());
+}
+
+TEST(PendingOperationsTest, N1_ResolveUnregisteredKey_ReturnsEmpty) {
+  VoidPending pending;
+
+  auto unblocked = pending.Resolve(42);
+  EXPECT_TRUE(unblocked.empty());
+}
+
+//==============================================================================
+// 1:N Pattern Tests (one waiter blocked by many keys)
+//==============================================================================
+
+TEST(PendingOperationsTest, 1N_SingleWaiterMultipleBlockers_ReturnsOnLast) {
+  PayloadPending pending;
+
+  auto r = pending.AddWaiter("w1", {"op1", "op2", "op3"}, 100);
+  EXPECT_FALSE(r.has_value());
+
+  auto u1 = pending.Resolve("op1");
+  EXPECT_TRUE(u1.empty()) << "Not all blockers resolved yet";
+
+  auto u2 = pending.Resolve("op2");
+  EXPECT_TRUE(u2.empty()) << "Not all blockers resolved yet";
+
+  auto u3 = pending.Resolve("op3");
+  ASSERT_EQ(u3.size(), 1u);
+  EXPECT_EQ(u3[0], 100);
+}
+
+TEST(PendingOperationsTest, 1N_MultipleWaitersOverlappingBlockers) {
+  PayloadPending pending;
+
+  // Waiter "w1" blocked by {A, B}
+  // Waiter "w2" blocked by {B, C}
+  pending.AddWaiter("w1", {"A", "B"}, 100);
+  pending.AddWaiter("w2", {"B", "C"}, 200);
+
+  auto u_a = pending.Resolve("A");
+  EXPECT_TRUE(u_a.empty()) << "w1 still blocked by B";
+
+  auto u_c = pending.Resolve("C");
+  EXPECT_TRUE(u_c.empty()) << "w2 still blocked by B";
+
+  // Resolving B should unblock both waiters
+  auto u_b = pending.Resolve("B");
+  ASSERT_EQ(u_b.size(), 2u);
+
+  std::sort(u_b.begin(), u_b.end());
+  EXPECT_EQ(u_b[0], 100);
+  EXPECT_EQ(u_b[1], 200);
+}
+
+//==============================================================================
+// Late Arrival Tests
+//==============================================================================
+
+TEST(PendingOperationsTest, LateArrival_RegisterResolveAdd_ReturnsImmediately) {
+  VoidPending pending;
+  pending.RegisterBlocker(1);
+
+  auto unblocked = pending.Resolve(1);
+  EXPECT_TRUE(unblocked.empty());
+
+  // Late arrival: AddWaiter after Resolve should return immediately
+  auto result = pending.AddWaiter("late_waiter", {1});
+  ASSERT_TRUE(result.has_value());
+  EXPECT_EQ(*result, "late_waiter");
+}
+
+TEST(PendingOperationsTest, LateArrival_MultipleRegistrations_DrainOneAtATime) {
+  VoidPending pending;
+  pending.RegisterBlocker(1);
+  pending.RegisterBlocker(1);  // refcount = 2
+
+  pending.Resolve(1);
+
+  // First late arrival drains one registration
+  auto r1 = pending.AddWaiter("late_1", {1});
+  ASSERT_TRUE(r1.has_value());
+  EXPECT_EQ(*r1, "late_1");
+
+  // Second late arrival drains the other registration
+  auto r2 = pending.AddWaiter("late_2", {1});
+  ASSERT_TRUE(r2.has_value());
+  EXPECT_EQ(*r2, "late_2");
+
+  // Now registration count is 0, tombstone should be cleaned up.
+  EXPECT_FALSE(pending.IsBlockerRegistered(1));
+}
+
+TEST(PendingOperationsTest, LateArrival_NotRegistered_NoTombstone) {
+  VoidPending pending;
+
+  // Resolve without Register — no tombstone created
+  pending.Resolve(1);
+
+  // AddWaiter should store (not return immediately) because there's no
+  // tombstone for unregistered blockers
+  auto result = pending.AddWaiter("waiter", {1});
+  EXPECT_FALSE(result.has_value()) << "No tombstone for unregistered blocker";
+
+  // Resolve again to release the stored waiter
+  auto unblocked = pending.Resolve(1);
+  ASSERT_EQ(unblocked.size(), 1u);
+  EXPECT_EQ(unblocked[0], "waiter");
+}
+
+TEST(PendingOperationsTest, LateArrival_WithPayload_ReturnsPayload) {
+  PayloadPending pending;
+  pending.RegisterBlocker("key");
+
+  pending.Resolve("key");
+
+  auto result = pending.AddWaiter("w1", {"key"}, 42);
+  ASSERT_TRUE(result.has_value());
+  EXPECT_EQ(*result, 42);
+}
+
+//==============================================================================
+// IsBlockerRegistered Tests
+//==============================================================================
+
+TEST(PendingOperationsTest, IsBlockerRegistered_TrueAfterRegister) {
+  VoidPending pending;
+  pending.RegisterBlocker(1);
+  EXPECT_TRUE(pending.IsBlockerRegistered(1));
+}
+
+TEST(PendingOperationsTest, IsBlockerRegistered_FalseForUnknownKey) {
+  VoidPending pending;
+  EXPECT_FALSE(pending.IsBlockerRegistered(42));
+}
+
+TEST(PendingOperationsTest, IsBlockerRegistered_TrueAfterResolve_UntilDrained) {
+  VoidPending pending;
+  pending.RegisterBlocker(1);
+
+  pending.Resolve(1);
+
+  // Registration persists until drained by late-arrival AddWaiter
+  EXPECT_TRUE(pending.IsBlockerRegistered(1));
+
+  // Drain via late arrival
+  auto result = pending.AddWaiter("late", {1});
+  ASSERT_TRUE(result.has_value());
+
+  // Now registration is drained
+  EXPECT_FALSE(pending.IsBlockerRegistered(1));
+}
+
+//==============================================================================
+// RemoveBlocker Tests
+//==============================================================================
+
+TEST(PendingOperationsTest, RemoveBlocker_ClearsRegistrationAndTombstone) {
+  VoidPending pending;
+  pending.RegisterBlocker(1);
+  pending.Resolve(1);
+
+  // Tombstone exists — verify via late arrival
+  pending.RemoveBlocker(1);
+
+  EXPECT_FALSE(pending.IsBlockerRegistered(1));
+
+  // After removal, tombstone is gone — AddWaiter stores the item
+  auto result = pending.AddWaiter("new_waiter", {1});
+  EXPECT_FALSE(result.has_value())
+      << "Tombstone should be gone after RemoveBlocker";
+}
+
+TEST(PendingOperationsTest, RemoveBlocker_ClearsReverseIndex) {
+  VoidPending pending;
+  pending.RegisterBlocker(1);
+
+  pending.AddWaiter("w1", {1});
+
+  // RemoveBlocker clears the reverse index (does NOT release waiters)
+  pending.RemoveBlocker(1);
+
+  // Resolving after RemoveBlocker should return nothing (reverse index gone)
+  auto unblocked = pending.Resolve(1);
+  EXPECT_TRUE(unblocked.empty());
+}
+
+//==============================================================================
+// RemoveWaiter Tests
+//==============================================================================
+
+TEST(PendingOperationsTest, RemoveWaiter_CleansUpWaiterAndReverseIndex) {
+  VoidPending pending;
+
+  pending.AddWaiter("w1", {1});
+  pending.AddWaiter("w2", {1});
+
+  // Remove w1 before resolving
+  pending.RemoveWaiter("w1");
+
+  // Resolve should only return w2
+  auto unblocked = pending.Resolve(1);
+  ASSERT_EQ(unblocked.size(), 1u);
+  EXPECT_EQ(unblocked[0], "w2");
+}
+
+TEST(PendingOperationsTest, RemoveWaiter_NonexistentWaiter_NoOp) {
+  VoidPending pending;
+
+  // Should not crash
+  pending.RemoveWaiter("does_not_exist");
+}
+
+TEST(PendingOperationsTest, RemoveWaiter_CleansUpMultipleBlockerRefs) {
+  PayloadPending pending;
+
+  pending.AddWaiter("w1", {"A", "B", "C"}, 100);
+
+  pending.RemoveWaiter("w1");
+
+  // Resolving any of the blockers should return nothing
+  EXPECT_TRUE(pending.Resolve("A").empty());
+  EXPECT_TRUE(pending.Resolve("B").empty());
+  EXPECT_TRUE(pending.Resolve("C").empty());
+}
+
+//==============================================================================
+// Mixed Pattern Tests
+//==============================================================================
+
+TEST(PendingOperationsTest, Mixed_N1And1N_Coexist) {
+  PayloadPending pending;
+
+  // N:1 pattern: multiple waiters blocked by "alpha"
+  pending.AddWaiter("w1", {"alpha"}, 1);
+  pending.AddWaiter("w2", {"alpha"}, 2);
+
+  // 1:N pattern: one waiter blocked by multiple keys
+  pending.AddWaiter("w3", {"alpha", "beta"}, 3);
+
+  // Resolve alpha: w1, w2 unblocked; w3 still blocked by beta
+  auto u_alpha = pending.Resolve("alpha");
+  ASSERT_EQ(u_alpha.size(), 2u);
+  std::sort(u_alpha.begin(), u_alpha.end());
+  EXPECT_EQ(u_alpha[0], 1);
+  EXPECT_EQ(u_alpha[1], 2);
+
+  // Resolve beta: w3 now fully unblocked
+  auto u_beta = pending.Resolve("beta");
+  ASSERT_EQ(u_beta.size(), 1u);
+  EXPECT_EQ(u_beta[0], 3);
+}
+
+TEST(PendingOperationsTest, Mixed_ResolveIdempotent) {
+  PayloadPending pending;
+
+  pending.AddWaiter("w1", {"key"}, 42);
+  auto u1 = pending.Resolve("key");
+  ASSERT_EQ(u1.size(), 1u);
+  EXPECT_EQ(u1[0], 42);
+
+  // Second resolve of same key returns nothing
+  auto u2 = pending.Resolve("key");
+  EXPECT_TRUE(u2.empty());
+}
+
+TEST(PendingOperationsTest, Mixed_VoidPayload_ReturnsWaiterIds) {
+  VoidPending pending;
+
+  pending.AddWaiter("client_1", {10});
+  pending.AddWaiter("client_2", {10});
+
+  auto unblocked = pending.Resolve(10);
+  ASSERT_EQ(unblocked.size(), 2u);
+
+  std::sort(unblocked.begin(), unblocked.end());
+  EXPECT_EQ(unblocked[0], "client_1");
+  EXPECT_EQ(unblocked[1], "client_2");
+}
+
+TEST(PendingOperationsTest, Mixed_PartialBlockersResolved_ViaRegistration) {
+  PayloadPending pending;
+  pending.RegisterBlocker("x");
+
+  // Resolve "x" (creates tombstone because registered)
+  pending.Resolve("x");
+
+  // Waiter has blockers {x, y} — x is resolved (tombstoned) but y is not
+  auto result = pending.AddWaiter("w1", {"x", "y"}, 50);
+  EXPECT_FALSE(result.has_value()) << "y is still unresolved";
+
+  // Now resolve y
+  auto unblocked = pending.Resolve("y");
+  ASSERT_EQ(unblocked.size(), 1u);
+  EXPECT_EQ(unblocked[0], 50);
+}
+
+TEST(PendingOperationsTest, Mixed_AllBlockersResolved_ViaRegistration) {
+  PayloadPending pending;
+  pending.RegisterBlocker("x");
+  pending.RegisterBlocker("y");
+
+  pending.Resolve("x");
+  pending.Resolve("y");
+
+  // All blockers resolved — returns immediately
+  auto result = pending.AddWaiter("w1", {"x", "y"}, 99);
+  ASSERT_TRUE(result.has_value());
+  EXPECT_EQ(*result, 99);
+}
+
+//==============================================================================
+}  // namespace
+//==============================================================================
+}  // namespace setu::test::native
+//==============================================================================

--- a/setu/client/client.py
+++ b/setu/client/client.py
@@ -73,12 +73,13 @@ class Client:
         """
         Disconnect from the NodeAgent.
 
-        This frees all registered shards and closes the connection.
-        Call this explicitly before the client goes out of scope to ensure
-        clean shutdown.
+        This deregisters all owned shards (notifying both the NodeAgent and
+        Coordinator) and closes the connection. Call this explicitly before
+        the client goes out of scope to ensure clean shutdown.
         """
         if self._client.is_connected():
             self._client.disconnect()
+            self._tensor_shard_cache.clear()
             logger.debug("Client disconnected from %s", self._endpoint)
 
     def register_tensor_shard(self, spec: TensorShardSpec) -> Optional[TensorShardRef]:

--- a/test/test_client_node_agent.py
+++ b/test/test_client_node_agent.py
@@ -304,23 +304,27 @@ def multi_node_infrastructure():
 @pytest.mark.gpu
 def test_register_overlapping_shard_returns_none(multi_node_infrastructure):
     """Test that registering overlapping shards returns None."""
-    from setu._commons.datatypes import TensorDimSpec
+    from setu._client import Client
+    from setu._commons.datatypes import Device, TensorDimSpec, TensorShardSpec
 
     infra = multi_node_infrastructure
     tensor_name = "overlapping_tensor"
 
-    # Register first shard covering rows [0, 600)
+    # Register first shard covering rows [0, 600) - keep client alive
+    client_0 = Client()
+    client_0.connect(infra["client_endpoint_0"])
+    device_0 = Device(torch_device=torch.device("cuda:0"))
     dims_0 = [
         TensorDimSpec("rows", 1024, 0, 600),
         TensorDimSpec("cols", 768, 0, 768),
     ]
-    shard_ref_0 = _register_tensor(
-        infra["client_endpoint_0"],
-        tensor_name,
-        dims_0,
-        infra["node_id_0"],
-        0,
+    shard_spec_0 = TensorShardSpec(
+        name=tensor_name,
+        dims=dims_0,
+        dtype=torch.float32,
+        device=device_0,
     )
+    shard_ref_0 = client_0.register_tensor_shard(shard_spec_0)
     assert shard_ref_0 is not None, "First shard should register successfully"
 
     # Attempt to register overlapping shard covering rows [400, 1024)
@@ -338,6 +342,8 @@ def test_register_overlapping_shard_returns_none(multi_node_infrastructure):
     )
     assert shard_ref_1 is None, "Overlapping shard should return None"
 
+    client_0.disconnect()
+
 
 @pytest.mark.gpu
 def test_register_dtype_mismatch_returns_none(multi_node_infrastructure):
@@ -348,7 +354,7 @@ def test_register_dtype_mismatch_returns_none(multi_node_infrastructure):
     infra = multi_node_infrastructure
     tensor_name = "dtype_mismatch_tensor"
 
-    # Register first shard with float32
+    # Register first shard with float32 - keep client alive
     dims = [
         TensorDimSpec("rows", 1024, 0, 512),
         TensorDimSpec("cols", 768, 0, 768),
@@ -364,7 +370,6 @@ def test_register_dtype_mismatch_returns_none(multi_node_infrastructure):
         device=device_0,
     )
     shard_ref_0 = client_0.register_tensor_shard(shard_spec_0)
-    client_0.disconnect()
     assert shard_ref_0 is not None, "First shard should register successfully"
 
     # Attempt to register second shard with float16 (dtype mismatch)
@@ -386,27 +391,33 @@ def test_register_dtype_mismatch_returns_none(multi_node_infrastructure):
     client_1.disconnect()
     assert shard_ref_1 is None, "Dtype mismatch shard should return None"
 
+    client_0.disconnect()
+
 
 @pytest.mark.gpu
 def test_register_dimension_size_mismatch_returns_none(multi_node_infrastructure):
     """Test that registering shards with mismatched dimension sizes returns None."""
-    from setu._commons.datatypes import TensorDimSpec
+    from setu._client import Client
+    from setu._commons.datatypes import Device, TensorDimSpec, TensorShardSpec
 
     infra = multi_node_infrastructure
     tensor_name = "dim_size_mismatch_tensor"
 
-    # Register first shard with rows total size 1024
+    # Register first shard with rows total size 1024 - keep client alive
+    client_0 = Client()
+    client_0.connect(infra["client_endpoint_0"])
+    device_0 = Device(torch_device=torch.device("cuda:0"))
     dims_0 = [
         TensorDimSpec("rows", 1024, 0, 512),
         TensorDimSpec("cols", 768, 0, 768),
     ]
-    shard_ref_0 = _register_tensor(
-        infra["client_endpoint_0"],
-        tensor_name,
-        dims_0,
-        infra["node_id_0"],
-        0,
+    shard_spec_0 = TensorShardSpec(
+        name=tensor_name,
+        dims=dims_0,
+        dtype=torch.float32,
+        device=device_0,
     )
+    shard_ref_0 = client_0.register_tensor_shard(shard_spec_0)
     assert shard_ref_0 is not None, "First shard should register successfully"
 
     # Attempt to register shard with rows total size 2048 (size mismatch)
@@ -423,27 +434,33 @@ def test_register_dimension_size_mismatch_returns_none(multi_node_infrastructure
     )
     assert shard_ref_1 is None, "Dimension size mismatch shard should return None"
 
+    client_0.disconnect()
+
 
 @pytest.mark.gpu
 def test_register_dimension_name_mismatch_returns_none(multi_node_infrastructure):
     """Test that registering shards with mismatched dimension names returns None."""
-    from setu._commons.datatypes import TensorDimSpec
+    from setu._client import Client
+    from setu._commons.datatypes import Device, TensorDimSpec, TensorShardSpec
 
     infra = multi_node_infrastructure
     tensor_name = "dim_name_mismatch_tensor"
 
-    # Register first shard with dimension names "rows" and "cols"
+    # Register first shard with dimension names "rows" and "cols" - keep client alive
+    client_0 = Client()
+    client_0.connect(infra["client_endpoint_0"])
+    device_0 = Device(torch_device=torch.device("cuda:0"))
     dims_0 = [
         TensorDimSpec("rows", 1024, 0, 512),
         TensorDimSpec("cols", 768, 0, 768),
     ]
-    shard_ref_0 = _register_tensor(
-        infra["client_endpoint_0"],
-        tensor_name,
-        dims_0,
-        infra["node_id_0"],
-        0,
+    shard_spec_0 = TensorShardSpec(
+        name=tensor_name,
+        dims=dims_0,
+        dtype=torch.float32,
+        device=device_0,
     )
+    shard_ref_0 = client_0.register_tensor_shard(shard_spec_0)
     assert shard_ref_0 is not None, "First shard should register successfully"
 
     # Attempt to register shard with different dimension names
@@ -460,27 +477,33 @@ def test_register_dimension_name_mismatch_returns_none(multi_node_infrastructure
     )
     assert shard_ref_1 is None, "Dimension name mismatch shard should return None"
 
+    client_0.disconnect()
+
 
 @pytest.mark.gpu
 def test_register_identical_shard_returns_none(multi_node_infrastructure):
     """Test that registering an identical (fully overlapping) shard returns None."""
-    from setu._commons.datatypes import TensorDimSpec
+    from setu._client import Client
+    from setu._commons.datatypes import Device, TensorDimSpec, TensorShardSpec
 
     infra = multi_node_infrastructure
     tensor_name = "identical_shard_tensor"
 
-    # Register first shard
+    # Register first shard - keep client alive
+    client_0 = Client()
+    client_0.connect(infra["client_endpoint_0"])
+    device_0 = Device(torch_device=torch.device("cuda:0"))
     dims = [
         TensorDimSpec("rows", 1024, 0, 512),
         TensorDimSpec("cols", 768, 0, 768),
     ]
-    shard_ref_0 = _register_tensor(
-        infra["client_endpoint_0"],
-        tensor_name,
-        dims,
-        infra["node_id_0"],
-        0,
+    shard_spec_0 = TensorShardSpec(
+        name=tensor_name,
+        dims=dims,
+        dtype=torch.float32,
+        device=device_0,
     )
+    shard_ref_0 = client_0.register_tensor_shard(shard_spec_0)
     assert shard_ref_0 is not None, "First shard should register successfully"
 
     # Attempt to register identical shard (same ranges)
@@ -493,6 +516,8 @@ def test_register_identical_shard_returns_none(multi_node_infrastructure):
     )
     assert shard_ref_1 is None, "Identical shard should return None (fully overlapping)"
 
+    client_0.disconnect()
+
 
 @pytest.mark.gpu
 def test_distributed_tensor_allocation(multi_node_infrastructure):
@@ -501,59 +526,315 @@ def test_distributed_tensor_allocation(multi_node_infrastructure):
     when a tensor is distributed across multiple nodes.
     """
     from setu._client import Client
-    from setu._commons.datatypes import TensorDimSpec
+    from setu._commons.datatypes import Device, TensorDimSpec, TensorShardSpec
 
     infra = multi_node_infrastructure
     tensor_name = "distributed_tensor"
     total_rows = 1024
 
-    # Node 0 owns rows [0, 512)
+    # Node 0 owns rows [0, 512) - keep client alive for handle retrieval
+    client_0 = Client()
+    client_0.connect(infra["client_endpoint_0"])
+    device_0 = Device(torch_device=torch.device("cuda:0"))
     dims_0 = [
         TensorDimSpec("rows", total_rows, 0, 512),
         TensorDimSpec("cols", 768, 0, 768),
     ]
-    shard_ref_0 = _register_tensor(
-        infra["client_endpoint_0"],
-        tensor_name,
-        dims_0,
-        infra["node_id_0"],
-        0,
+    shard_spec_0 = TensorShardSpec(
+        name=tensor_name,
+        dims=dims_0,
+        dtype=torch.float32,
+        device=device_0,
     )
+    shard_ref_0 = client_0.register_tensor_shard(shard_spec_0)
     assert shard_ref_0 is not None
 
-    # Node 1 owns rows [512, 1024)
+    # Node 1 owns rows [512, 1024) - keep client alive for handle retrieval
+    client_1 = Client()
+    client_1.connect(infra["client_endpoint_1"])
+    device_1 = Device(torch_device=torch.device("cuda:1"))
     dims_1 = [
         TensorDimSpec("rows", total_rows, 512, 1024),
         TensorDimSpec("cols", 768, 0, 768),
     ]
-    shard_ref_1 = _register_tensor(
-        infra["client_endpoint_1"],
-        tensor_name,
-        dims_1,
-        infra["node_id_1"],
-        1,
+    shard_spec_1 = TensorShardSpec(
+        name=tensor_name,
+        dims=dims_1,
+        dtype=torch.float32,
+        device=device_1,
     )
+    shard_ref_1 = client_1.register_tensor_shard(shard_spec_1)
     assert shard_ref_1 is not None
 
     # Wait for AllocateTensorRequest to be processed
     time.sleep(0.5)
 
     # Verify both NodeAgents allocated the tensor by getting handles
-    client_0 = Client()
-    client_0.connect(infra["client_endpoint_0"])
     ipc_spec_0, metadata_0, lock_dir_0 = client_0.get_tensor_handle(shard_ref_0)
-    client_0.disconnect()
-
-    client_1 = Client()
-    client_1.connect(infra["client_endpoint_1"])
     ipc_spec_1, metadata_1, lock_dir_1 = client_1.get_tensor_handle(shard_ref_1)
-    client_1.disconnect()
 
     assert ipc_spec_0 is not None, "NodeAgent 0 should have allocated tensor"
     assert ipc_spec_1 is not None, "NodeAgent 1 should have allocated tensor"
 
     assert ipc_spec_0.to_dict()["tensor_size"] == [512, 768]
     assert ipc_spec_1.to_dict()["tensor_size"] == [512, 768]
+
+    client_0.disconnect()
+    client_1.disconnect()
+
+
+def _register_and_get_handle_with_timing(
+    endpoint: str,
+    tensor_name: str,
+    dims_data,
+    result_queue,
+    register_done_event,
+    device_index: int = 0,
+):
+    """
+    Register a tensor shard, signal completion, then get handle with timing.
+    Used to test waiting_for_allocation_clients_ mechanism.
+
+    Args:
+        dims_data: List of tuples (name, total_size, start, end) for each dimension.
+                   TensorDimSpec objects are created inside the subprocess to avoid pickling issues.
+    """
+    from setu._client import Client
+    from setu._commons.datatypes import Device, TensorDimSpec, TensorShardSpec
+
+    client = Client()
+    client.connect(endpoint)
+
+    # Create TensorDimSpec objects inside subprocess (can't pickle C++ objects)
+    dims_spec = [
+        TensorDimSpec(name, total, start, end) for name, total, start, end in dims_data
+    ]
+
+    device = Device(torch_device=torch.device(f"cuda:{device_index}"))
+    shard_spec = TensorShardSpec(
+        name=tensor_name,
+        dims=dims_spec,
+        dtype=torch.float32,
+        device=device,
+    )
+
+    # Register the shard
+    shard_ref = client.register_tensor_shard(shard_spec)
+    if shard_ref is None:
+        result_queue.put({"error": "Failed to register shard"})
+        client.disconnect()
+        return
+
+    # Signal that registration is done
+    register_done_event.set()
+
+    # Now get handle - this should block until tensor is allocated
+    get_handle_start = time.time()
+    tensor_ipc_spec, metadata, lock_base_dir = client.get_tensor_handle(shard_ref)
+    get_handle_end = time.time()
+
+    client.disconnect()
+
+    result_queue.put(
+        {
+            "shard_id": shard_ref.shard_id,
+            "tensor_size": tensor_ipc_spec.to_dict()["tensor_size"],
+            "get_handle_start": get_handle_start,
+            "get_handle_end": get_handle_end,
+        }
+    )
+
+
+def _register_with_timing(
+    endpoint: str,
+    tensor_name: str,
+    dims_data,
+    result_queue,
+    device_index: int = 0,
+):
+    """
+    Register a tensor shard and report timing.
+
+    Args:
+        dims_data: List of tuples (name, total_size, start, end) for each dimension.
+                   TensorDimSpec objects are created inside the subprocess to avoid pickling issues.
+    """
+    from setu._client import Client
+    from setu._commons.datatypes import Device, TensorDimSpec, TensorShardSpec
+
+    client = Client()
+    client.connect(endpoint)
+
+    # Create TensorDimSpec objects inside subprocess (can't pickle C++ objects)
+    dims_spec = [
+        TensorDimSpec(name, total, start, end) for name, total, start, end in dims_data
+    ]
+
+    device = Device(torch_device=torch.device(f"cuda:{device_index}"))
+    shard_spec = TensorShardSpec(
+        name=tensor_name,
+        dims=dims_spec,
+        dtype=torch.float32,
+        device=device,
+    )
+
+    register_time = time.time()
+    shard_ref = client.register_tensor_shard(shard_spec)
+
+    client.disconnect()
+
+    result_queue.put(
+        {
+            "shard_id": shard_ref.shard_id if shard_ref else None,
+            "register_time": register_time,
+        }
+    )
+
+
+@pytest.mark.gpu
+def test_disconnect_clears_client_shards(infrastructure):
+    """Test that disconnecting clears the client's local shard tracking."""
+    from setu._client import Client
+    from setu._commons.datatypes import Device, TensorDimSpec, TensorShardSpec
+
+    client_endpoint = infrastructure["client_endpoint"]
+
+    client = Client()
+    client.connect(client_endpoint)
+
+    device = Device(torch_device=torch.device("cuda:0"))
+    dims = [
+        TensorDimSpec("dim_0", 16, 0, 16),
+        TensorDimSpec("dim_1", 32, 0, 32),
+    ]
+    shard_spec = TensorShardSpec(
+        name="deregister_local_test",
+        dims=dims,
+        dtype=torch.float32,
+        device=device,
+    )
+
+    shard_ref = client.register_tensor_shard(shard_spec)
+    assert shard_ref is not None
+    assert len(client.get_shards()) == 1
+
+    client.disconnect()
+
+    # After disconnect, client should have no shards
+    assert len(client.get_shards()) == 0
+
+
+@pytest.mark.gpu
+def test_disconnect_allows_reregistration(infrastructure):
+    """
+    Test that after a client disconnects, a new client can re-register
+    the same tensor ranges. This proves deregistration cleaned up server state.
+    """
+    from setu._client import Client
+    from setu._commons.datatypes import Device, TensorDimSpec, TensorShardSpec
+
+    client_endpoint = infrastructure["client_endpoint"]
+    tensor_name = "reregister_test_tensor"
+
+    device = Device(torch_device=torch.device("cuda:0"))
+    dims = [
+        TensorDimSpec("dim_0", 8, 0, 8),
+        TensorDimSpec("dim_1", 16, 0, 16),
+    ]
+    shard_spec = TensorShardSpec(
+        name=tensor_name,
+        dims=dims,
+        dtype=torch.float32,
+        device=device,
+    )
+
+    # First client registers and disconnects
+    client1 = Client()
+    client1.connect(client_endpoint)
+    shard_ref1 = client1.register_tensor_shard(shard_spec)
+    assert shard_ref1 is not None, "First registration should succeed"
+    client1.disconnect()
+
+    # Small delay to let cleanup propagate
+    time.sleep(0.2)
+
+    # Second client re-registers the same tensor range
+    client2 = Client()
+    client2.connect(client_endpoint)
+    shard_ref2 = client2.register_tensor_shard(shard_spec)
+    assert shard_ref2 is not None, "Re-registration should succeed after deregistration"
+
+    # Verify re-registered shard is usable
+    tensor_ipc_spec, metadata, lock_base_dir = client2.get_tensor_handle(shard_ref2)
+    assert tensor_ipc_spec is not None
+    spec_dict = tensor_ipc_spec.to_dict()
+    assert spec_dict["tensor_size"] == [8, 16]
+
+    client2.disconnect()
+
+
+@pytest.mark.gpu
+def test_disconnect_multiple_shards_deregistered(infrastructure):
+    """
+    Test that disconnecting deregisters all shards owned by the client,
+    even when the client owns multiple shards for different tensors.
+    """
+    from setu._client import Client
+    from setu._commons.datatypes import Device, TensorDimSpec, TensorShardSpec
+
+    client_endpoint = infrastructure["client_endpoint"]
+
+    client = Client()
+    client.connect(client_endpoint)
+
+    device = Device(torch_device=torch.device("cuda:0"))
+
+    # Register shards for 3 different tensors
+    tensor_configs = [
+        ("deregister_multi_a", 4, 8),
+        ("deregister_multi_b", 16, 32),
+        ("deregister_multi_c", 2, 4),
+    ]
+    for tensor_name, d0_size, d1_size in tensor_configs:
+        dims = [
+            TensorDimSpec("dim_0", d0_size, 0, d0_size),
+            TensorDimSpec("dim_1", d1_size, 0, d1_size),
+        ]
+        shard_spec = TensorShardSpec(
+            name=tensor_name,
+            dims=dims,
+            dtype=torch.float32,
+            device=device,
+        )
+        shard_ref = client.register_tensor_shard(shard_spec)
+        assert shard_ref is not None, f"Failed to register {tensor_name}"
+
+    assert len(client.get_shards()) == 3
+    client.disconnect()
+
+    time.sleep(0.2)
+
+    # Verify all 3 tensors can be re-registered by a new client
+    client2 = Client()
+    client2.connect(client_endpoint)
+
+    for tensor_name, d0_size, d1_size in tensor_configs:
+        dims = [
+            TensorDimSpec("dim_0", d0_size, 0, d0_size),
+            TensorDimSpec("dim_1", d1_size, 0, d1_size),
+        ]
+        shard_spec = TensorShardSpec(
+            name=tensor_name,
+            dims=dims,
+            dtype=torch.float32,
+            device=device,
+        )
+        shard_ref = client2.register_tensor_shard(shard_spec)
+        assert (
+            shard_ref is not None
+        ), f"Re-registration of {tensor_name} should succeed after deregistration"
+
+    client2.disconnect()
 
 
 if __name__ == "__main__":

--- a/test/test_deferred_deregistration.py
+++ b/test/test_deferred_deregistration.py
@@ -1,0 +1,1128 @@
+"""
+Integration tests for deferred shard deregistration.
+
+Tests that when a client disconnects while copy operations are in-flight,
+deregistration is deferred until all blocking copies complete. Specifically:
+
+1. Disconnect with no pending copies → immediate cleanup (no regression)
+2. Disconnect while copy is in-flight → deregistration waits for copy to
+   complete, then cleans up
+3. After deferred deregistration completes, re-registration works
+4. Multiple blocking copies → deregistration waits for all
+"""
+
+import time
+import uuid
+
+import pytest
+import torch
+import torch.multiprocessing as mp
+from torch.multiprocessing.reductions import rebuild_cuda_tensor
+
+
+def _run_coordinator(port: int, ready_event, stop_event):
+    """Run the Coordinator in a separate process."""
+    from setu._coordinator import Coordinator, NCCLBackend, PassManager, Planner
+
+    backend = NCCLBackend()
+    pass_manager = PassManager()
+    planner = Planner(backend, pass_manager)
+
+    coordinator = Coordinator(port, planner)
+    coordinator.start()
+    ready_event.set()
+
+    while not stop_event.is_set():
+        time.sleep(0.05)
+
+    coordinator.stop()
+
+
+def _run_node_agent(
+    port: int,
+    coordinator_endpoint: str,
+    ready_event,
+    stop_event,
+    node_id=None,
+    device_indices=None,
+):
+    """Run the NodeAgent in a separate process."""
+    from setu._commons.datatypes import Device
+    from setu._node_manager import NodeAgent
+
+    if node_id is None:
+        node_id = uuid.uuid4()
+
+    if device_indices is None:
+        device_indices = [0]
+
+    devices = [Device(torch_device=torch.device(f"cuda:{i}")) for i in device_indices]
+
+    node_agent = NodeAgent(
+        node_id=node_id,
+        port=port,
+        coordinator_endpoint=coordinator_endpoint,
+        devices=devices,
+    )
+    node_agent.start()
+    ready_event.set()
+
+    while not stop_event.is_set():
+        time.sleep(0.05)
+
+    node_agent.stop()
+
+
+def _rebuild_tensor_from_handle(tensor_ipc_spec):
+    """Rebuild a CUDA tensor from an IPC spec."""
+    spec_dict = tensor_ipc_spec.to_dict()
+    args = {
+        **spec_dict,
+        "tensor_cls": torch.Tensor,
+        "storage_cls": torch.storage.UntypedStorage,
+    }
+    return rebuild_cuda_tensor(**args)
+
+
+# ==============================================================================
+# Subprocess helpers for deferred deregistration tests
+# ==============================================================================
+
+
+def _run_source_client_with_disconnect(
+    client_endpoint: str,
+    tensor_name: str,
+    dims_data: list,
+    init_value: float,
+    init_done_event,
+    start_disconnect_event,
+    result_queue,
+    device_index: int = 0,
+):
+    """
+    Source client process:
+    1. Register source shard and initialize data
+    2. Signal initialization done
+    3. Wait for disconnect signal
+    4. Disconnect (blocks until all copies involving our shards complete)
+    5. Report timing to result queue
+
+    Args:
+        dims_data: List of tuples (name, global_size, start, end).
+    """
+    from setu._client import Client
+    from setu._commons.datatypes import Device, TensorDimSpec, TensorShardSpec
+
+    try:
+        client = Client()
+        client.connect(client_endpoint)
+
+        dims_spec = [
+            TensorDimSpec(name, global_size, start, end)
+            for name, global_size, start, end in dims_data
+        ]
+
+        device = Device(torch_device=torch.device(f"cuda:{device_index}"))
+        shard_spec = TensorShardSpec(
+            name=tensor_name,
+            dims=dims_spec,
+            dtype=torch.float32,
+            device=device,
+        )
+
+        shard_ref = client.register_tensor_shard(shard_spec)
+        if shard_ref is None:
+            raise RuntimeError(f"Failed to register source shard {tensor_name}")
+
+        client.wait_for_shard_allocation(shard_ref.shard_id)
+
+        # Get tensor handle and initialize data
+        tensor_ipc_spec, _, _ = client.get_tensor_handle(shard_ref)
+        tensor = _rebuild_tensor_from_handle(tensor_ipc_spec)
+        tensor.fill_(init_value)
+        torch.cuda.synchronize()
+
+        # Signal that initialization is done
+        init_done_event.set()
+
+        # Wait for the signal to disconnect
+        start_disconnect_event.wait(timeout=60)
+
+        # Disconnect — this sends DeregisterShardsRequest, which will block
+        # until all copy operations involving our shards complete
+        disconnect_start = time.time()
+        client.disconnect()
+        disconnect_end = time.time()
+
+        result_queue.put(
+            {
+                "success": True,
+                "disconnect_start": disconnect_start,
+                "disconnect_end": disconnect_end,
+                "disconnect_duration": disconnect_end - disconnect_start,
+            }
+        )
+
+    except Exception as e:
+        import traceback
+
+        result_queue.put(
+            {
+                "success": False,
+                "error": str(e),
+                "traceback": traceback.format_exc(),
+            }
+        )
+
+
+def _run_dest_client_pull(
+    client_endpoint: str,
+    src_tensor_name: str,
+    dst_tensor_name: str,
+    dims_data: list,
+    source_ready_event,
+    pull_submitted_event,
+    expected_value: float,
+    result_queue,
+    device_index: int = 0,
+):
+    """
+    Destination client process:
+    1. Wait for source to be ready
+    2. Register destination shard
+    3. Submit pull operation
+    4. Signal that pull was submitted
+    5. Wait for copy to complete and verify data
+
+    Args:
+        dims_data: List of tuples (name, global_size, start, end).
+    """
+    from setu._client import Client
+    from setu._commons.datatypes import (
+        CopySpec,
+        Device,
+        TensorDim,
+        TensorDimSpec,
+        TensorSelection,
+        TensorShardSpec,
+    )
+
+    try:
+        # Wait for source data to be initialized
+        if not source_ready_event.wait(timeout=30):
+            raise RuntimeError("Timeout waiting for source initialization")
+
+        client = Client()
+        client.connect(client_endpoint)
+
+        dims_spec = [
+            TensorDimSpec(name, global_size, start, end)
+            for name, global_size, start, end in dims_data
+        ]
+
+        device = Device(torch_device=torch.device(f"cuda:{device_index}"))
+        shard_spec = TensorShardSpec(
+            name=dst_tensor_name,
+            dims=dims_spec,
+            dtype=torch.float32,
+            device=device,
+        )
+
+        shard_ref = client.register_tensor_shard(shard_spec)
+        if shard_ref is None:
+            raise RuntimeError(f"Failed to register dest shard {dst_tensor_name}")
+
+        client.wait_for_shard_allocation(shard_ref.shard_id)
+
+        # Build CopySpec
+        dim_map = {}
+        for name, global_size, start, end in dims_data:
+            dim_map[name] = TensorDim(name, global_size)
+
+        src_selection = TensorSelection(src_tensor_name, dim_map)
+        dst_selection = TensorSelection(dst_tensor_name, dim_map)
+        copy_spec = CopySpec(
+            src_tensor_name, dst_tensor_name, src_selection, dst_selection
+        )
+
+        # Submit pull operation
+        copy_op_id = client.submit_pull(copy_spec)
+        if copy_op_id is None:
+            raise RuntimeError("Failed to submit pull operation")
+
+        # Signal that pull was submitted — main test can now trigger disconnect
+        if pull_submitted_event is not None:
+            pull_submitted_event.set()
+
+        # Wait for copy to complete
+        client.wait_for_copy(copy_op_id)
+
+        # Verify data
+        tensor_ipc_spec, _, _ = client.get_tensor_handle(shard_ref)
+        tensor = _rebuild_tensor_from_handle(tensor_ipc_spec)
+        torch.cuda.synchronize()
+
+        actual_value = tensor.mean().item()
+        values_match = abs(actual_value - expected_value) < 1e-5
+
+        result_queue.put(
+            {
+                "success": True,
+                "expected_value": expected_value,
+                "actual_value": actual_value,
+                "values_match": values_match,
+            }
+        )
+
+        client.disconnect()
+
+    except Exception as e:
+        import traceback
+
+        result_queue.put(
+            {
+                "success": False,
+                "error": str(e),
+                "traceback": traceback.format_exc(),
+            }
+        )
+
+
+# ==============================================================================
+# Tests
+# ==============================================================================
+
+
+@pytest.mark.gpu
+def test_disconnect_no_pending_copies_immediate():
+    """
+    Test that disconnect with no pending copies completes immediately.
+
+    This is a regression test to ensure the new deferred deregistration
+    logic doesn't add unnecessary delay when there are no blocking copies.
+    """
+    if not torch.cuda.is_available():
+        pytest.skip("CUDA not available")
+
+    coordinator_port = 29700
+    node_agent_port = 29701
+    coordinator_endpoint = f"tcp://localhost:{coordinator_port}"
+    client_endpoint = f"tcp://localhost:{node_agent_port}"
+
+    ctx = mp.get_context("spawn")
+    coordinator_ready = ctx.Event()
+    node_agent_ready = ctx.Event()
+    stop_event = ctx.Event()
+
+    processes = []
+
+    try:
+        # Start infrastructure
+        coordinator_proc = ctx.Process(
+            target=_run_coordinator,
+            args=(coordinator_port, coordinator_ready, stop_event),
+        )
+        coordinator_proc.start()
+        processes.append(coordinator_proc)
+        assert coordinator_ready.wait(timeout=10), "Coordinator failed to start"
+
+        node_agent_proc = ctx.Process(
+            target=_run_node_agent,
+            args=(node_agent_port, coordinator_endpoint, node_agent_ready, stop_event),
+        )
+        node_agent_proc.start()
+        processes.append(node_agent_proc)
+        assert node_agent_ready.wait(timeout=10), "NodeAgent failed to start"
+
+        time.sleep(0.2)
+
+        # Register shards and disconnect immediately (no copies submitted)
+        source_init_done = ctx.Event()
+        start_disconnect = ctx.Event()
+        source_result_queue = ctx.Queue()
+
+        source_proc = ctx.Process(
+            target=_run_source_client_with_disconnect,
+            args=(
+                client_endpoint,
+                "no_copy_tensor",
+                [("rows", 8, 0, 8), ("cols", 8, 0, 8)],
+                1.0,
+                source_init_done,
+                start_disconnect,
+                source_result_queue,
+            ),
+        )
+        source_proc.start()
+        processes.append(source_proc)
+
+        # Wait for source to initialize, then immediately signal disconnect
+        assert source_init_done.wait(timeout=10), "Source failed to initialize"
+        start_disconnect.set()
+
+        # Collect result
+        source_result = source_result_queue.get(timeout=10)
+        assert source_result[
+            "success"
+        ], f"Source disconnect failed: {source_result.get('error')}"
+
+        # Disconnect should be fast (< 2 seconds) when no copies are pending
+        assert source_result["disconnect_duration"] < 2.0, (
+            f"Disconnect took {source_result['disconnect_duration']:.2f}s, "
+            f"expected < 2s for no pending copies"
+        )
+
+        # Brief delay for cleanup to propagate
+        time.sleep(0.3)
+
+        # Verify re-registration works (proves deregistration happened)
+        reregister_result = ctx.Queue()
+        reregister_proc = ctx.Process(
+            target=_verify_reregistration,
+            args=(
+                client_endpoint,
+                "no_copy_tensor",
+                [("rows", 8, 0, 8), ("cols", 8, 0, 8)],
+                reregister_result,
+            ),
+        )
+        reregister_proc.start()
+        processes.append(reregister_proc)
+
+        result = reregister_result.get(timeout=10)
+        assert result["success"], f"Re-registration failed: {result.get('error')}"
+
+    finally:
+        stop_event.set()
+        time.sleep(0.2)
+        for proc in processes:
+            proc.terminate()
+            proc.join(timeout=2)
+            if proc.is_alive():
+                proc.kill()
+
+
+@pytest.mark.gpu
+def test_disconnect_during_active_copy_waits():
+    """
+    Test that disconnect blocks until in-flight copy operations complete.
+
+    Setup:
+    - Source client registers and initializes data
+    - Dest client registers and submits pull
+    - Source client disconnects while copy may be in-flight
+    - Verify: pull completes with correct data, disconnect returns after copy
+
+    This is the core test for deferred deregistration.
+    """
+    if not torch.cuda.is_available():
+        pytest.skip("CUDA not available")
+
+    coordinator_port = 29710
+    node_agent_port = 29711
+    coordinator_endpoint = f"tcp://localhost:{coordinator_port}"
+    client_endpoint = f"tcp://localhost:{node_agent_port}"
+    init_value = 42.0
+
+    ctx = mp.get_context("spawn")
+    coordinator_ready = ctx.Event()
+    node_agent_ready = ctx.Event()
+    stop_event = ctx.Event()
+
+    source_init_done = ctx.Event()
+    pull_submitted = ctx.Event()
+    start_disconnect = ctx.Event()
+
+    source_result_queue = ctx.Queue()
+    dest_result_queue = ctx.Queue()
+
+    processes = []
+
+    try:
+        # Start Coordinator
+        coordinator_proc = ctx.Process(
+            target=_run_coordinator,
+            args=(coordinator_port, coordinator_ready, stop_event),
+        )
+        coordinator_proc.start()
+        processes.append(coordinator_proc)
+        assert coordinator_ready.wait(timeout=10), "Coordinator failed to start"
+
+        # Start NodeAgent
+        node_agent_proc = ctx.Process(
+            target=_run_node_agent,
+            args=(node_agent_port, coordinator_endpoint, node_agent_ready, stop_event),
+        )
+        node_agent_proc.start()
+        processes.append(node_agent_proc)
+        assert node_agent_ready.wait(timeout=10), "NodeAgent failed to start"
+
+        time.sleep(0.2)
+
+        dims_data = [("rows", 4, 0, 4), ("cols", 4, 0, 4)]
+
+        # Start source client
+        source_proc = ctx.Process(
+            target=_run_source_client_with_disconnect,
+            args=(
+                client_endpoint,
+                "active_copy_src",
+                dims_data,
+                init_value,
+                source_init_done,
+                start_disconnect,
+                source_result_queue,
+            ),
+        )
+        source_proc.start()
+        processes.append(source_proc)
+
+        # Start dest client
+        dest_proc = ctx.Process(
+            target=_run_dest_client_pull,
+            args=(
+                client_endpoint,
+                "active_copy_src",
+                "active_copy_dst",
+                dims_data,
+                source_init_done,
+                pull_submitted,
+                init_value,
+                dest_result_queue,
+            ),
+        )
+        dest_proc.start()
+        processes.append(dest_proc)
+
+        # Wait for pull to be submitted, then trigger source disconnect
+        assert pull_submitted.wait(timeout=30), "Pull was not submitted in time"
+        start_disconnect.set()
+
+        # Collect destination result — pull should succeed
+        dest_result = dest_result_queue.get(timeout=60)
+        assert dest_result["success"], (
+            f"Dest client failed: {dest_result.get('error')}\n"
+            f"{dest_result.get('traceback', '')}"
+        )
+        assert dest_result["values_match"], (
+            f"Data mismatch: expected {dest_result['expected_value']}, "
+            f"got {dest_result['actual_value']}"
+        )
+
+        # Collect source result — disconnect should have succeeded
+        source_result = source_result_queue.get(timeout=30)
+        assert source_result["success"], (
+            f"Source disconnect failed: {source_result.get('error')}\n"
+            f"{source_result.get('traceback', '')}"
+        )
+
+        # Brief delay for cleanup to propagate
+        time.sleep(0.3)
+
+        # Verify re-registration works after deferred deregistration
+        reregister_result = ctx.Queue()
+        reregister_proc = ctx.Process(
+            target=_verify_reregistration,
+            args=(
+                client_endpoint,
+                "active_copy_src",
+                dims_data,
+                reregister_result,
+            ),
+        )
+        reregister_proc.start()
+        processes.append(reregister_proc)
+
+        result = reregister_result.get(timeout=10)
+        assert result["success"], (
+            f"Re-registration after deferred deregistration failed: "
+            f"{result.get('error')}"
+        )
+
+    finally:
+        stop_event.set()
+        time.sleep(0.2)
+        for proc in processes:
+            proc.terminate()
+            proc.join(timeout=2)
+            if proc.is_alive():
+                proc.kill()
+
+
+@pytest.mark.gpu
+def test_disconnect_with_multiple_blocking_copies():
+    """
+    Test that disconnect waits for ALL blocking copies to complete.
+
+    Setup:
+    - Source client registers source tensor
+    - 2 dest clients each pull into separate dest tensors
+    - Source disconnects while both copies may be in-flight
+    - Both copies should succeed and source should deregister cleanly
+    """
+    if not torch.cuda.is_available():
+        pytest.skip("CUDA not available")
+
+    coordinator_port = 29720
+    node_agent_port = 29721
+    coordinator_endpoint = f"tcp://localhost:{coordinator_port}"
+    client_endpoint = f"tcp://localhost:{node_agent_port}"
+    init_value = 99.0
+
+    ctx = mp.get_context("spawn")
+    coordinator_ready = ctx.Event()
+    node_agent_ready = ctx.Event()
+    stop_event = ctx.Event()
+
+    source_init_done = ctx.Event()
+    pull_submitted_0 = ctx.Event()
+    pull_submitted_1 = ctx.Event()
+    start_disconnect = ctx.Event()
+
+    source_result_queue = ctx.Queue()
+    dest_result_queue_0 = ctx.Queue()
+    dest_result_queue_1 = ctx.Queue()
+
+    processes = []
+
+    try:
+        # Start Coordinator
+        coordinator_proc = ctx.Process(
+            target=_run_coordinator,
+            args=(coordinator_port, coordinator_ready, stop_event),
+        )
+        coordinator_proc.start()
+        processes.append(coordinator_proc)
+        assert coordinator_ready.wait(timeout=10), "Coordinator failed to start"
+
+        # Start NodeAgent
+        node_agent_proc = ctx.Process(
+            target=_run_node_agent,
+            args=(node_agent_port, coordinator_endpoint, node_agent_ready, stop_event),
+        )
+        node_agent_proc.start()
+        processes.append(node_agent_proc)
+        assert node_agent_ready.wait(timeout=10), "NodeAgent failed to start"
+
+        time.sleep(0.2)
+
+        dims_data = [("rows", 4, 0, 4), ("cols", 4, 0, 4)]
+
+        # Start source client
+        source_proc = ctx.Process(
+            target=_run_source_client_with_disconnect,
+            args=(
+                client_endpoint,
+                "multi_copy_src",
+                dims_data,
+                init_value,
+                source_init_done,
+                start_disconnect,
+                source_result_queue,
+            ),
+        )
+        source_proc.start()
+        processes.append(source_proc)
+
+        # Start 2 dest clients pulling from the same source
+        dest_proc_0 = ctx.Process(
+            target=_run_dest_client_pull,
+            args=(
+                client_endpoint,
+                "multi_copy_src",
+                "multi_copy_dst_0",
+                dims_data,
+                source_init_done,
+                pull_submitted_0,
+                init_value,
+                dest_result_queue_0,
+            ),
+        )
+        dest_proc_0.start()
+        processes.append(dest_proc_0)
+
+        dest_proc_1 = ctx.Process(
+            target=_run_dest_client_pull,
+            args=(
+                client_endpoint,
+                "multi_copy_src",
+                "multi_copy_dst_1",
+                dims_data,
+                source_init_done,
+                pull_submitted_1,
+                init_value,
+                dest_result_queue_1,
+            ),
+        )
+        dest_proc_1.start()
+        processes.append(dest_proc_1)
+
+        # Wait for both pulls to be submitted, then trigger disconnect
+        assert pull_submitted_0.wait(timeout=30), "Pull 0 not submitted in time"
+        assert pull_submitted_1.wait(timeout=30), "Pull 1 not submitted in time"
+        start_disconnect.set()
+
+        # Collect results from both destinations
+        dest_result_0 = dest_result_queue_0.get(timeout=60)
+        assert dest_result_0["success"], (
+            f"Dest 0 failed: {dest_result_0.get('error')}\n"
+            f"{dest_result_0.get('traceback', '')}"
+        )
+        assert dest_result_0["values_match"], (
+            f"Dest 0 data mismatch: expected {dest_result_0['expected_value']}, "
+            f"got {dest_result_0['actual_value']}"
+        )
+
+        dest_result_1 = dest_result_queue_1.get(timeout=60)
+        assert dest_result_1["success"], (
+            f"Dest 1 failed: {dest_result_1.get('error')}\n"
+            f"{dest_result_1.get('traceback', '')}"
+        )
+        assert dest_result_1["values_match"], (
+            f"Dest 1 data mismatch: expected {dest_result_1['expected_value']}, "
+            f"got {dest_result_1['actual_value']}"
+        )
+
+        # Collect source result
+        source_result = source_result_queue.get(timeout=30)
+        assert source_result["success"], (
+            f"Source disconnect failed: {source_result.get('error')}\n"
+            f"{source_result.get('traceback', '')}"
+        )
+
+        # Verify re-registration
+        time.sleep(0.3)
+        reregister_result = ctx.Queue()
+        reregister_proc = ctx.Process(
+            target=_verify_reregistration,
+            args=(
+                client_endpoint,
+                "multi_copy_src",
+                dims_data,
+                reregister_result,
+            ),
+        )
+        reregister_proc.start()
+        processes.append(reregister_proc)
+
+        result = reregister_result.get(timeout=10)
+        assert result["success"], (
+            f"Re-registration failed after multi-copy deregistration: "
+            f"{result.get('error')}"
+        )
+
+    finally:
+        stop_event.set()
+        time.sleep(0.2)
+        for proc in processes:
+            proc.terminate()
+            proc.join(timeout=2)
+            if proc.is_alive():
+                proc.kill()
+
+
+@pytest.mark.gpu
+def test_disconnect_after_copy_completes_allows_reregistration():
+    """
+    Test that after a copy completes and source disconnects,
+    the same tensor ranges can be re-registered by a new client.
+    """
+    if not torch.cuda.is_available():
+        pytest.skip("CUDA not available")
+
+    coordinator_port = 29730
+    node_agent_port = 29731
+    coordinator_endpoint = f"tcp://localhost:{coordinator_port}"
+    client_endpoint = f"tcp://localhost:{node_agent_port}"
+    init_value = 7.0
+
+    ctx = mp.get_context("spawn")
+    coordinator_ready = ctx.Event()
+    node_agent_ready = ctx.Event()
+    stop_event = ctx.Event()
+
+    source_init_done = ctx.Event()
+    start_disconnect = ctx.Event()
+    source_result_queue = ctx.Queue()
+    dest_result_queue = ctx.Queue()
+
+    processes = []
+
+    try:
+        # Start infrastructure
+        coordinator_proc = ctx.Process(
+            target=_run_coordinator,
+            args=(coordinator_port, coordinator_ready, stop_event),
+        )
+        coordinator_proc.start()
+        processes.append(coordinator_proc)
+        assert coordinator_ready.wait(timeout=10)
+
+        node_agent_proc = ctx.Process(
+            target=_run_node_agent,
+            args=(node_agent_port, coordinator_endpoint, node_agent_ready, stop_event),
+        )
+        node_agent_proc.start()
+        processes.append(node_agent_proc)
+        assert node_agent_ready.wait(timeout=10)
+
+        time.sleep(0.2)
+
+        dims_data = [("rows", 4, 0, 4), ("cols", 4, 0, 4)]
+
+        # Start source
+        source_proc = ctx.Process(
+            target=_run_source_client_with_disconnect,
+            args=(
+                client_endpoint,
+                "reregister_src",
+                dims_data,
+                init_value,
+                source_init_done,
+                start_disconnect,
+                source_result_queue,
+            ),
+        )
+        source_proc.start()
+        processes.append(source_proc)
+
+        # Start dest — pull_submitted_event is None since we don't need it
+        dest_proc = ctx.Process(
+            target=_run_dest_client_pull,
+            args=(
+                client_endpoint,
+                "reregister_src",
+                "reregister_dst",
+                dims_data,
+                source_init_done,
+                None,  # No pull_submitted event needed
+                init_value,
+                dest_result_queue,
+            ),
+        )
+        dest_proc.start()
+        processes.append(dest_proc)
+
+        # Wait for dest to complete (copy finishes)
+        dest_result = dest_result_queue.get(timeout=60)
+        assert dest_result["success"], (
+            f"Dest failed: {dest_result.get('error')}\n"
+            f"{dest_result.get('traceback', '')}"
+        )
+
+        # Now disconnect source (copy already completed, should be immediate)
+        start_disconnect.set()
+
+        source_result = source_result_queue.get(timeout=10)
+        assert source_result[
+            "success"
+        ], f"Source disconnect failed: {source_result.get('error')}"
+        # Should be fast since copy already completed
+        assert source_result["disconnect_duration"] < 2.0, (
+            f"Disconnect took {source_result['disconnect_duration']:.2f}s, "
+            f"expected < 2s when copy already completed"
+        )
+
+        time.sleep(0.3)
+
+        # Re-register the same source tensor range
+        reregister_result = ctx.Queue()
+        reregister_proc = ctx.Process(
+            target=_verify_reregistration,
+            args=(
+                client_endpoint,
+                "reregister_src",
+                dims_data,
+                reregister_result,
+            ),
+        )
+        reregister_proc.start()
+        processes.append(reregister_proc)
+
+        result = reregister_result.get(timeout=10)
+        assert result["success"], f"Re-registration failed: {result.get('error')}"
+
+    finally:
+        stop_event.set()
+        time.sleep(0.2)
+        for proc in processes:
+            proc.terminate()
+            proc.join(timeout=2)
+            if proc.is_alive():
+                proc.kill()
+
+
+@pytest.mark.gpu
+def test_registration_rejected_on_partially_deregistered_tensor():
+    """
+    Test that registering a shard on a partially-deregistered tensor is rejected.
+
+    Setup:
+    - Client A registers shard (rows 0-4) for tensor
+    - Client B registers shard (rows 4-8) for tensor
+    - Client A disconnects (no copies, immediate deregistration)
+    - Tensor is now partially freed (has_deregistered_shards=true)
+    - Client C tries to register a new shard → should get None (rejected)
+    """
+    if not torch.cuda.is_available():
+        pytest.skip("CUDA not available")
+
+    coordinator_port = 29740
+    node_agent_port = 29741
+    coordinator_endpoint = f"tcp://localhost:{coordinator_port}"
+    client_endpoint = f"tcp://localhost:{node_agent_port}"
+
+    ctx = mp.get_context("spawn")
+    coordinator_ready = ctx.Event()
+    node_agent_ready = ctx.Event()
+    stop_event = ctx.Event()
+
+    processes = []
+
+    try:
+        # Start infrastructure
+        coordinator_proc = ctx.Process(
+            target=_run_coordinator,
+            args=(coordinator_port, coordinator_ready, stop_event),
+        )
+        coordinator_proc.start()
+        processes.append(coordinator_proc)
+        assert coordinator_ready.wait(timeout=10), "Coordinator failed to start"
+
+        node_agent_proc = ctx.Process(
+            target=_run_node_agent,
+            args=(node_agent_port, coordinator_endpoint, node_agent_ready, stop_event),
+        )
+        node_agent_proc.start()
+        processes.append(node_agent_proc)
+        assert node_agent_ready.wait(timeout=10), "NodeAgent failed to start"
+
+        time.sleep(0.2)
+
+        tensor_name = "partial_dereg_tensor"
+
+        # Client A registers rows 0-4, then disconnects
+        client_a_init_done = ctx.Event()
+        client_a_disconnect = ctx.Event()
+        client_a_result = ctx.Queue()
+
+        client_a_proc = ctx.Process(
+            target=_run_source_client_with_disconnect,
+            args=(
+                client_endpoint,
+                tensor_name,
+                [("rows", 8, 0, 4), ("cols", 8, 0, 8)],
+                1.0,
+                client_a_init_done,
+                client_a_disconnect,
+                client_a_result,
+            ),
+        )
+        client_a_proc.start()
+        processes.append(client_a_proc)
+
+        # Client B registers rows 4-8 (keeps tensor alive)
+        client_b_init_done = ctx.Event()
+        client_b_disconnect = ctx.Event()
+        client_b_result = ctx.Queue()
+
+        client_b_proc = ctx.Process(
+            target=_run_source_client_with_disconnect,
+            args=(
+                client_endpoint,
+                tensor_name,
+                [("rows", 8, 4, 8), ("cols", 8, 0, 8)],
+                2.0,
+                client_b_init_done,
+                client_b_disconnect,
+                client_b_result,
+            ),
+        )
+        client_b_proc.start()
+        processes.append(client_b_proc)
+
+        # Wait for both to initialize
+        assert client_a_init_done.wait(timeout=10), "Client A failed to init"
+        assert client_b_init_done.wait(timeout=10), "Client B failed to init"
+
+        # Disconnect Client A — no copies, immediate deregistration
+        # Tensor is now partially freed (Client B's shards still exist)
+        client_a_disconnect.set()
+        a_result = client_a_result.get(timeout=10)
+        assert a_result[
+            "success"
+        ], f"Client A disconnect failed: {a_result.get('error')}"
+
+        time.sleep(0.3)
+
+        # Client C tries to register a new shard on the same tensor
+        # This should be rejected because the tensor is partially deregistered
+        registration_result = ctx.Queue()
+        client_c_proc = ctx.Process(
+            target=_attempt_registration_expect_rejection,
+            args=(
+                client_endpoint,
+                tensor_name,
+                [("rows", 8, 0, 4), ("cols", 8, 0, 8)],
+                registration_result,
+            ),
+        )
+        client_c_proc.start()
+        processes.append(client_c_proc)
+
+        result = registration_result.get(timeout=10)
+        assert result["success"], (
+            f"Test failed: {result.get('error')}\n" f"{result.get('traceback', '')}"
+        )
+        assert result["registration_rejected"], (
+            "Registration should have been rejected on partially-deregistered "
+            "tensor, but it succeeded"
+        )
+
+        # Clean up Client B
+        client_b_disconnect.set()
+        b_result = client_b_result.get(timeout=10)
+        assert b_result[
+            "success"
+        ], f"Client B disconnect failed: {b_result.get('error')}"
+
+    finally:
+        stop_event.set()
+        time.sleep(0.2)
+        for proc in processes:
+            proc.terminate()
+            proc.join(timeout=2)
+            if proc.is_alive():
+                proc.kill()
+
+
+# ==============================================================================
+# Helper subprocess functions
+# ==============================================================================
+
+
+def _verify_reregistration(
+    client_endpoint: str,
+    tensor_name: str,
+    dims_data: list,
+    result_queue,
+    device_index: int = 0,
+):
+    """
+    Verify that a tensor can be re-registered after deregistration.
+
+    Registers the same tensor name with the same dims, then verifies the
+    shard_ref is valid. Reports success/failure to result_queue.
+    """
+    from setu._client import Client
+    from setu._commons.datatypes import Device, TensorDimSpec, TensorShardSpec
+
+    try:
+        client = Client()
+        client.connect(client_endpoint)
+
+        dims_spec = [
+            TensorDimSpec(name, global_size, start, end)
+            for name, global_size, start, end in dims_data
+        ]
+
+        device = Device(torch_device=torch.device(f"cuda:{device_index}"))
+        shard_spec = TensorShardSpec(
+            name=tensor_name,
+            dims=dims_spec,
+            dtype=torch.float32,
+            device=device,
+        )
+
+        shard_ref = client.register_tensor_shard(shard_spec)
+        if shard_ref is None:
+            result_queue.put(
+                {
+                    "success": False,
+                    "error": (
+                        f"Re-registration returned None for '{tensor_name}' — "
+                        f"deregistration may not have completed"
+                    ),
+                }
+            )
+        else:
+            result_queue.put(
+                {
+                    "success": True,
+                    "shard_id": shard_ref.shard_id,
+                }
+            )
+
+        client.disconnect()
+
+    except Exception as e:
+        import traceback
+
+        result_queue.put(
+            {
+                "success": False,
+                "error": str(e),
+                "traceback": traceback.format_exc(),
+            }
+        )
+
+
+def _attempt_registration_expect_rejection(
+    client_endpoint: str,
+    tensor_name: str,
+    dims_data: list,
+    result_queue,
+    device_index: int = 0,
+):
+    """
+    Attempt to register a shard and report whether registration was rejected.
+
+    Reports success=True with registration_rejected=True/False indicating
+    whether the registration returned None (rejected).
+    """
+    from setu._client import Client
+    from setu._commons.datatypes import Device, TensorDimSpec, TensorShardSpec
+
+    try:
+        client = Client()
+        client.connect(client_endpoint)
+
+        dims_spec = [
+            TensorDimSpec(name, global_size, start, end)
+            for name, global_size, start, end in dims_data
+        ]
+
+        device = Device(torch_device=torch.device(f"cuda:{device_index}"))
+        shard_spec = TensorShardSpec(
+            name=tensor_name,
+            dims=dims_spec,
+            dtype=torch.float32,
+            device=device,
+        )
+
+        shard_ref = client.register_tensor_shard(shard_spec)
+
+        result_queue.put(
+            {
+                "success": True,
+                "registration_rejected": shard_ref is None,
+            }
+        )
+
+        client.disconnect()
+
+    except Exception as e:
+        import traceback
+
+        result_queue.put(
+            {
+                "success": False,
+                "error": str(e),
+                "traceback": traceback.format_exc(),
+            }
+        )
+
+
+if __name__ == "__main__":
+    mp.set_start_method("spawn")
+    pytest.main([__file__, "-v", "-s", "--gpu"])


### PR DESCRIPTION
## Summary
- Add client-initiated shard deregistration via `free_shards()` API with deferred cleanup
- New `DeregisterShardsRequest/Response` messaging types and `MetaStore` for ownership tracking
- Add `ShardAggregator` for batching shard submissions and extend `PendingOperations` with completion callbacks