### PR TITLE
Change Pass::Run to take Program by value

### DIFF
--- a/csrc/setu/planner/passes/Pass.h
+++ b/csrc/setu/planner/passes/Pass.h
@@ -31,7 +31,7 @@ using setu::planner::hints::HintStore;
 class Pass : public setu::commons::NonCopyableNonMovable {
  public:
   virtual ~Pass() = default;
-  [[nodiscard]] virtual cir::Program Run(const cir::Program& program,
+  [[nodiscard]] virtual cir::Program Run(cir::Program program,
                                          const HintStore& hints) = 0;
   [[nodiscard]] virtual std::string Name() const = 0;
 };

--- a/csrc/setu/planner/passes/PassManager.cpp
+++ b/csrc/setu/planner/passes/PassManager.cpp
@@ -28,7 +28,7 @@ void PassManager::AddPass(PassPtr pass) {
 cir::Program PassManager::Run(cir::Program program,
                               const HintStore& hints) const {
   for (const auto& pass : passes_) {
-    program = pass->Run(program, hints);
+    program = pass->Run(std::move(program), hints);
     LOG_DEBUG("After pass '{}': {}", pass->Name(), program.Dump());
   }
   return program;

--- a/csrc/setu/planner/passes/ShortestPathRouting.cpp
+++ b/csrc/setu/planner/passes/ShortestPathRouting.cpp
@@ -10,7 +10,7 @@ using setu::planner::hints::RoutingHint;
 using setu::planner::topo::Link;
 using setu::planner::topo::Path;
 
-cir::Program ShortestPathRouting::Run(const cir::Program& program,
+cir::Program ShortestPathRouting::Run(cir::Program program,
                                       const HintStore& hints) {
   // Calculate override map from routing hints
   std::map<std::pair<Participant, Participant>,

--- a/csrc/setu/planner/passes/ShortestPathRouting.h
+++ b/csrc/setu/planner/passes/ShortestPathRouting.h
@@ -29,7 +29,7 @@ using setu::planner::topo::TopologyPtr;
 class ShortestPathRouting : public Pass {
  public:
   explicit ShortestPathRouting(TopologyPtr topo) : topo_(std::move(topo)) {}
-  [[nodiscard]] cir::Program Run(const cir::Program& program,
+  [[nodiscard]] cir::Program Run(cir::Program program,
                                  const HintStore& hints) override;
   [[nodiscard]] std::string Name() const override {
     return "ShortestPathRouting";


### PR DESCRIPTION
## Summary
- Change `Pass::Run` signature to take `Program` by value instead of const reference
- Enables move semantics through the pass pipeline, avoiding unnecessary copies
- Update PassManager, ShortestPathRouting, and tests accordingly