### PR TITLE
Allow null topology for ShortestPathRouting pass

### DIFF
--- a/csrc/setu/planner/passes/Pybind.cpp
+++ b/csrc/setu/planner/passes/Pybind.cpp
@@ -39,8 +39,8 @@ void InitPassesPybind(py::module_& m) {
 
   py::class_<ShortestPathRouting, Pass, std::shared_ptr<ShortestPathRouting>>(
       m, "ShortestPathRouting")
-      .def(py::init<TopologyPtr>(), py::arg("topology"),
-           "Create a ShortestPathRouting pass with the given topology");
+      .def(py::init<TopologyPtr>(), py::arg("topology").none(true),
+           "Create a ShortestPathRouting pass with an optional topology");
 }
 //==============================================================================
 }  // namespace setu::planner::passes

--- a/csrc/setu/planner/passes/ShortestPathRouting.cpp
+++ b/csrc/setu/planner/passes/ShortestPathRouting.cpp
@@ -12,6 +12,12 @@ using setu::planner::topo::Path;
 
 cir::Program ShortestPathRouting::Run(cir::Program program,
                                       const HintStore& hints) {
+  // No topology and no routing hints — every copy would resolve to a direct
+  // 2-hop path and be cloned unchanged, so skip the rewrite entirely.
+  if (!topo_ && hints.GetHints<RoutingHint>().empty()) {
+    return program;
+  }
+
   // Calculate override map from routing hints
   std::map<std::pair<Participant, Participant>,
            std::reference_wrapper<const Path>>
@@ -40,7 +46,12 @@ cir::Program ShortestPathRouting::Run(cir::Program program,
               if (override_it != overrides.end()) {
                 return override_it->second.get();
               }
-              // No override defined, calculate shortest path
+              // No override defined — use topology if available,
+              // otherwise fall back to a direct 2-hop path.
+              if (!topo_) {
+                return Path({src_val_info.device, dst_val_info.device},
+                            {Link(0.0f, 1.0f)});
+              }
               auto path_opt =
                   topo_->ShortestPath(src_val_info.device, dst_val_info.device,
                                       [bytes](const Link& l) -> float {


### PR DESCRIPTION
## Summary
- Allow ShortestPathRouting pass to accept null topology, skipping routing when no topology or hints are provided
- Add fallback direct path when topology is null but routing hints override the path