### PR TITLE
Add telemetry metrics infrastructure

### DIFF
--- a/cmake/Extensions.cmake
+++ b/cmake/Extensions.cmake
@@ -111,6 +111,9 @@ file(GLOB_RECURSE PLANNER_SRC "csrc/setu/planner/*.cpp")
 define_setu_static(_planner_static "${PLANNER_SRC}" "setu_common_objects"
                    "${NCCL_LIBRARY};_metastore_static")
 
+file(GLOB_RECURSE TELEMETRY_SRC "csrc/setu/telemetry/*.cpp")
+define_setu_static(_telemetry_static "${TELEMETRY_SRC}" "setu_common_objects" "")
+
 file(GLOB_RECURSE MESSAGES_SRC "csrc/setu/messaging/*.cpp")
 define_setu_static(_messaging_static "${MESSAGES_SRC}" "setu_common_objects" "_planner_static")
 
@@ -120,15 +123,15 @@ define_setu_static(_client_static "${CLIENT_SRC}" "setu_common_objects" "_messag
 
 file(GLOB_RECURSE NODE_MANAGER_SRC "csrc/setu/node_manager/*.cpp")
 define_setu_extension(_node_manager "${NODE_MANAGER_SRC}" "setu_common_objects"
-                      "_kernels_common;_messaging_static;_planner_static")
+                      "_kernels_common;_messaging_static;_planner_static;_telemetry_static")
 define_setu_static(_node_manager_static "${NODE_MANAGER_SRC}" "setu_common_objects"
-                   "_kernels_common;_messaging_static;_planner_static")
+                   "_kernels_common;_messaging_static;_planner_static;_telemetry_static")
 
 file(GLOB_RECURSE COORDINATOR_SRC "csrc/setu/coordinator/*.cpp")
 define_setu_extension(_coordinator "${COORDINATOR_SRC}" "setu_common_objects"
-                      "_messaging_static;_metastore_static;_planner_static")
+                      "_messaging_static;_metastore_static;_planner_static;_telemetry_static")
 define_setu_static(_coordinator_static "${COORDINATOR_SRC}" "setu_common_objects"
-                   "_messaging_static;_metastore_static;_planner_static")
+                   "_messaging_static;_metastore_static;_planner_static;_telemetry_static")
 target_include_directories(_coordinator PRIVATE ${NCCL_INCLUDE_DIR})
 target_include_directories(_coordinator_static PRIVATE ${NCCL_INCLUDE_DIR})
 

--- a/csrc/setu/coordinator/Coordinator.cpp
+++ b/csrc/setu/coordinator/Coordinator.cpp
@@ -22,19 +22,34 @@ namespace setu::coordinator {
 //==============================================================================
 using setu::commons::datatypes::CopySpec;
 //==============================================================================
-Coordinator::Coordinator(std::size_t port, PlannerPtr planner)
+Coordinator::Coordinator(std::size_t port, PlannerPtr planner,
+                         std::string metrics_endpoint)
     : port_(port),
+      metrics_endpoint_(std::move(metrics_endpoint)),
       zmq_context_(std::make_shared<zmq::context_t>()),
       planner_(planner) {
+  // Create MetricsSink instances if metrics_endpoint is configured.
+  // Each thread gets its own sink (ZMQ sockets are not thread-safe).
+  setu::telemetry::MetricsSinkPtr handler_sink;
+  setu::telemetry::MetricsSinkPtr executor_sink;
+  if (!metrics_endpoint_.empty()) {
+    handler_sink = std::make_shared<setu::telemetry::MetricsSink>(
+        zmq_context_, metrics_endpoint_);
+    executor_sink = std::make_shared<setu::telemetry::MetricsSink>(
+        zmq_context_, metrics_endpoint_);
+  }
+
   gateway_ = std::make_unique<Gateway>(zmq_context_, port_, inbox_queue_,
                                        outbox_queue_);
 
   auto outbox_notify = [this]() { gateway_->NotifyOutbox(); };
 
-  handler_ = std::make_unique<Handler>(inbox_queue_, outbox_queue_, metastore_,
-                                       planner_queue_, outbox_notify);
-  executor_ = std::make_unique<Executor>(planner_queue_, outbox_queue_,
-                                         metastore_, *planner_, outbox_notify);
+  handler_ =
+      std::make_unique<Handler>(inbox_queue_, outbox_queue_, metastore_,
+                                planner_queue_, outbox_notify, handler_sink);
+  executor_ =
+      std::make_unique<Executor>(planner_queue_, outbox_queue_, metastore_,
+                                 *planner_, outbox_notify, executor_sink);
 }
 
 Coordinator::~Coordinator() {

--- a/csrc/setu/coordinator/Coordinator.h
+++ b/csrc/setu/coordinator/Coordinator.h
@@ -29,6 +29,7 @@
 #include "coordinator/Types.h"
 #include "metastore/MetaStore.h"
 #include "planner/Planner.h"
+#include "telemetry/MetricsSink.h"
 //==============================================================================
 namespace setu::coordinator {
 //==============================================================================
@@ -51,7 +52,8 @@ using setu::planner::PlannerPtr;
 /// communicating through thread-safe queues.
 class Coordinator {
  public:
-  Coordinator(std::size_t port, PlannerPtr planner);
+  Coordinator(std::size_t port, PlannerPtr planner,
+              std::string metrics_endpoint = "");
   ~Coordinator();
 
   std::optional<TensorShardMetadata> RegisterTensorShard(
@@ -66,6 +68,7 @@ class Coordinator {
 
  private:
   std::size_t port_;
+  std::string metrics_endpoint_;
 
   std::shared_ptr<zmq::context_t> zmq_context_;
 

--- a/csrc/setu/coordinator/DispatchManager.h
+++ b/csrc/setu/coordinator/DispatchManager.h
@@ -161,6 +161,7 @@ class DispatchManager {
 
     auto state = std::make_shared<CopyOperationState>(completed.spec,
                                                       std::move(submitters));
+    state->start_time = std::chrono::high_resolution_clock::now();
 
     copy_operations_.emplace(copy_op_id, state);
 

--- a/csrc/setu/coordinator/Executor.cpp
+++ b/csrc/setu/coordinator/Executor.cpp
@@ -28,12 +28,14 @@ using setu::planner::Plan;
 //==============================================================================
 Executor::Executor(Queue<PlannerTask>& planner_queue,
                    Queue<OutboxMessage>& outbox_queue, MetaStore& metastore,
-                   Planner& planner, OutboxNotifyFn outbox_notify)
+                   Planner& planner, OutboxNotifyFn outbox_notify,
+                   setu::telemetry::MetricsSinkPtr metrics_sink)
     : planner_queue_(planner_queue),
       outbox_queue_(outbox_queue),
       metastore_(metastore),
       planner_(planner),
-      outbox_notify_(std::move(outbox_notify)) {}
+      outbox_notify_(std::move(outbox_notify)),
+      metrics_sink_(std::move(metrics_sink)) {}
 
 void Executor::PushOutbox(OutboxMessage msg) {
   outbox_queue_.push(std::move(msg));
@@ -65,9 +67,15 @@ void Executor::Loop() {
 
       LOG_DEBUG("Executor received task for copy_op_id: {}", task.copy_op_id);
 
-      auto t_compile_start = std::chrono::steady_clock::now();
-      Plan plan = planner_.Compile(task.copy_spec, metastore_, task.hints);
-      auto t_compile_end = std::chrono::steady_clock::now();
+      auto result = planner_.Compile(task.copy_spec, metastore_, task.hints,
+                                     task.copy_op_id);
+      Plan plan = std::move(result.plan);
+
+      // Submit compilation metrics
+      if (metrics_sink_ && metrics_sink_->IsEnabled()) {
+        metrics_sink_->Submit(
+            setu::telemetry::MetricsMessage{std::move(result.metrics)});
+      }
 
       LOG_DEBUG("Compiled plan:\n{}", plan);
 
@@ -93,11 +101,8 @@ void Executor::Loop() {
       auto to_us = [](auto d) {
         return std::chrono::duration_cast<std::chrono::microseconds>(d).count();
       };
-      LOG_INFO(
-          "Executor: copy_op_id={}, compile={}us, fragment+dispatch={}us, "
-          "total={}us",
-          task.copy_op_id, to_us(t_compile_end - t_compile_start),
-          to_us(t_end - t_compile_end), to_us(t_end - t_after_dequeue));
+      LOG_INFO("Executor: copy_op_id={}, total={}us", task.copy_op_id,
+               to_us(t_end - t_after_dequeue));
 
     } catch (const boost::concurrent::sync_queue_is_closed&) {
       return;

--- a/csrc/setu/coordinator/Handler.cpp
+++ b/csrc/setu/coordinator/Handler.cpp
@@ -37,12 +37,14 @@ using setu::commons::utils::AggregationParticipant;
 Handler::Handler(Queue<InboxMessage>& inbox_queue,
                  Queue<OutboxMessage>& outbox_queue, MetaStore& metastore,
                  Queue<PlannerTask>& planner_queue,
-                 OutboxNotifyFn outbox_notify)
+                 OutboxNotifyFn outbox_notify,
+                 setu::telemetry::MetricsSinkPtr metrics_sink)
     : inbox_queue_(inbox_queue),
       outbox_queue_(outbox_queue),
       metastore_(metastore),
       planner_queue_(planner_queue),
-      outbox_notify_(std::move(outbox_notify)) {}
+      outbox_notify_(std::move(outbox_notify)),
+      metrics_sink_(std::move(metrics_sink)) {}
 
 void Handler::PushOutbox(OutboxMessage msg) {
   outbox_queue_.push(std::move(msg));
@@ -290,6 +292,19 @@ void Handler::HandleExecuteResponse(const Identity& /*node_identity*/,
 
   // All participants completed — notify submitters
   const auto& state = *completed_state;
+
+  // Submit E2E timing metrics
+  if (metrics_sink_ && metrics_sink_->IsEnabled()) {
+    double e2e_ms =
+        std::chrono::duration<double, std::milli>(
+            std::chrono::high_resolution_clock::now() - state->start_time)
+            .count();
+    setu::telemetry::E2EMetrics e2e;
+    e2e.copy_op_id = response.copy_op_id;
+    e2e.e2e_time_ms = e2e_ms;
+    metrics_sink_->Submit(setu::telemetry::MetricsMessage{e2e});
+  }
+
   for (const auto& submitter_identity : state->submitters) {
     CopyOperationFinishedRequest finish_req(response.copy_op_id);
     PushOutbox(OutboxMessage{submitter_identity, finish_req});

--- a/csrc/setu/coordinator/Handler.h
+++ b/csrc/setu/coordinator/Handler.h
@@ -25,6 +25,7 @@
 #include "coordinator/Types.h"
 #include "messaging/Messages.h"
 #include "metastore/MetaStore.h"
+#include "telemetry/MetricsSink.h"
 //==============================================================================
 namespace setu::coordinator {
 //==============================================================================
@@ -50,7 +51,8 @@ class Handler {
  public:
   Handler(Queue<InboxMessage>& inbox_queue, Queue<OutboxMessage>& outbox_queue,
           MetaStore& metastore, Queue<PlannerTask>& planner_queue,
-          OutboxNotifyFn outbox_notify);
+          OutboxNotifyFn outbox_notify,
+          setu::telemetry::MetricsSinkPtr metrics_sink);
 
   void Start();
   void Stop();
@@ -82,6 +84,7 @@ class Handler {
   MetaStore& metastore_;
   Queue<PlannerTask>& planner_queue_;
   OutboxNotifyFn outbox_notify_;
+  setu::telemetry::MetricsSinkPtr metrics_sink_;
 
   DispatchManager dispatch_manager_;
 

--- a/csrc/setu/coordinator/Pybind.cpp
+++ b/csrc/setu/coordinator/Pybind.cpp
@@ -28,9 +28,10 @@ using setu::planner::PlannerPtr;
 //==============================================================================
 void InitCoordinatorPybindClass(py::module_& m) {
   py::class_<Coordinator, std::shared_ptr<Coordinator>>(m, "Coordinator")
-      .def(py::init<std::size_t, PlannerPtr>(), py::arg("port"),
-           py::arg("planner"),
-           "Create a Coordinator with specified port and planner")
+      .def(py::init<std::size_t, PlannerPtr, std::string>(), py::arg("port"),
+           py::arg("planner"), py::arg("metrics_endpoint") = "",
+           "Create a Coordinator with specified port, planner, and optional "
+           "metrics endpoint")
       .def("start", &Coordinator::Start, "Start the Coordinator loops")
       .def("stop", &Coordinator::Stop, "Stop the Coordinator loops");
 }

--- a/csrc/setu/coordinator/Types.h
+++ b/csrc/setu/coordinator/Types.h
@@ -76,6 +76,9 @@ struct CopyOperationState {
 
   std::size_t completed_responses{0};  // Handler-thread only (not shared)
 
+  /// @brief Timestamp when the copy operation was first submitted.
+  std::chrono::high_resolution_clock::time_point start_time;
+
   explicit CopyOperationState(CopySpec spec_param,
                               std::vector<Identity> submitters_param)
       : spec(std::move(spec_param)), submitters(std::move(submitters_param)) {}

--- a/csrc/setu/messaging/Pybind.cpp
+++ b/csrc/setu/messaging/Pybind.cpp
@@ -25,6 +25,7 @@
 //==============================================================================
 namespace setu::commons::messages {
 //==============================================================================
+using setu::commons::CopyOperationId;
 using setu::commons::RequestId;
 using setu::commons::datatypes::TensorShardMetadata;
 using setu::commons::datatypes::TensorShardRef;
@@ -83,8 +84,11 @@ void InitRegisterTensorShardNodeAgentResponsePybind(py::module_& m) {
 void InitExecuteProgramRequestPybind(py::module_& m) {
   py::class_<ExecuteProgramRequest>(m, "ExecuteProgramRequest",
                                     py::module_local())
-      .def(py::init<Program>(), py::arg("program"),
-           "Create an ExecuteProgramRequest with a program")
+      .def(py::init<CopyOperationId, Program>(), py::arg("copy_op_id"),
+           py::arg("program"),
+           "Create an ExecuteProgramRequest with a copy_op_id and program")
+      .def_readonly("copy_op_id", &ExecuteProgramRequest::copy_op_id,
+                    "The copy operation ID")
       .def_readonly("program", &ExecuteProgramRequest::program,
                     "The program to execute")
       .def("__str__", &ExecuteProgramRequest::ToString)

--- a/csrc/setu/node_manager/NodeAgent.cpp
+++ b/csrc/setu/node_manager/NodeAgent.cpp
@@ -20,6 +20,7 @@
 #include "commons/utils/Comm.h"
 #include "commons/utils/TorchTensorIPC.h"
 #include "node_manager/worker/NCCLWorker.h"
+#include "telemetry/MetricsSink.h"
 //==============================================================================
 namespace setu::node_manager {
 //==============================================================================
@@ -79,13 +80,14 @@ constexpr std::int32_t kPollTimeoutMs = 100;
 NodeAgent::NodeAgent(NodeId node_id, std::size_t port,
                      std::string coordinator_endpoint,
                      const std::vector<Device>& devices,
-                     std::string lock_base_dir)
+                     std::string lock_base_dir, std::string metrics_endpoint)
     : node_id_(node_id),
       port_(port),
       coordinator_endpoint_(std::move(coordinator_endpoint)),
       devices_(devices),
       zmq_context_(std::make_shared<zmq::context_t>()),
-      lock_base_dir_(std::move(lock_base_dir)) {
+      lock_base_dir_(std::move(lock_base_dir)),
+      metrics_endpoint_(std::move(metrics_endpoint)) {
   // Create workers and connect them via inproc sockets on the shared context
   for (const auto& device : devices_) {
     auto device_rank = device.LocalDeviceIndex();
@@ -93,6 +95,14 @@ NodeAgent::NodeAgent(NodeId node_id, std::size_t port,
         std::format("inproc://node_{}_worker_{}", node_id_, device_rank);
     auto worker = std::make_unique<worker::NCCLWorker>(node_id_, device);
     worker->Connect(zmq_context_, endpoint);
+
+    // Set up telemetry sink for each worker (each gets its own ZMQ socket)
+    if (!metrics_endpoint_.empty()) {
+      auto sink = std::make_shared<setu::telemetry::MetricsSink>(
+          zmq_context_, metrics_endpoint_);
+      worker->SetMetricsSink(std::move(sink));
+    }
+
     workers_.emplace(device_rank, std::move(worker));
   }
 
@@ -710,7 +720,7 @@ void NodeAgent::Executor::Loop() {
         // Send ExecuteProgramRequest to worker
         LOG_DEBUG("Sending program with {} instructions to worker {}",
                   program.size(), device_rank);
-        ExecuteProgramRequest request(program);
+        ExecuteProgramRequest request(copy_op_id, program);
         Comm::Send(it->second, request);
         sent_device_ranks.push_back(device_rank);
       }

--- a/csrc/setu/node_manager/NodeAgent.h
+++ b/csrc/setu/node_manager/NodeAgent.h
@@ -91,7 +91,8 @@ class NodeAgent {
  public:
   NodeAgent(NodeId node_id, std::size_t port, std::string coordinator_endpoint,
             const std::vector<Device>& devices,
-            std::string lock_base_dir = GetDefaultLockBaseDir());
+            std::string lock_base_dir = GetDefaultLockBaseDir(),
+            std::string metrics_endpoint = "");
   ~NodeAgent();
 
   void Start();
@@ -264,6 +265,8 @@ class NodeAgent {
 
   TensorShardsConcurrentMap shard_id_to_tensor_;
   std::string lock_base_dir_;  ///< Directory for file-based locks (IPC)
+  std::string
+      metrics_endpoint_;  ///< Telemetry server endpoint (empty = disabled)
 };
 //==============================================================================
 }  // namespace setu::node_manager

--- a/csrc/setu/node_manager/Pybind.cpp
+++ b/csrc/setu/node_manager/Pybind.cpp
@@ -67,12 +67,13 @@ void InitWorkerPybindClass(py::module_& m) {
 void InitNodeAgentPybindClass(py::module_& m) {
   py::class_<NodeAgent, std::shared_ptr<NodeAgent>>(m, "NodeAgent")
       .def(py::init<NodeId, std::size_t, std::string,
-                    const std::vector<Device>&, std::string>(),
+                    const std::vector<Device>&, std::string, std::string>(),
            py::arg("node_id"), py::arg("port"), py::arg("coordinator_endpoint"),
            py::arg("devices"),
            py::arg("lock_base_dir") = NodeAgent::GetDefaultLockBaseDir(),
+           py::arg("metrics_endpoint") = "",
            "Create a NodeAgent with specified port, coordinator endpoint, "
-           "devices, and lock directory")
+           "devices, lock directory, and optional metrics endpoint")
       .def("start", &NodeAgent::Start, "Start the NodeAgent handler loop")
       .def("stop", &NodeAgent::Stop, "Stop the NodeAgent handler loop");
 }

--- a/csrc/setu/node_manager/worker/NCCLWorker.cpp
+++ b/csrc/setu/node_manager/worker/NCCLWorker.cpp
@@ -65,55 +65,106 @@ void NCCLWorker::Setup() {
 }
 
 void NCCLWorker::Execute(const Program& program) {
+  auto t_start = std::chrono::high_resolution_clock::now();
+
   bool group_started = false;
+  std::uint32_t group_index = 0;
+  std::size_t ops_in_group = 0;
+  std::vector<GroupTimingState> event_states;
+  std::vector<setu::telemetry::NCCLGroupTiming> timings;
 
   for (const auto& instruction : program) {
-    ExecuteInstruction(instruction, group_started);
+    std::visit(
+        [&](const auto& inst) {
+          using T = std::decay_t<decltype(inst)>;
+
+          if constexpr (std::is_same_v<T, InitComm>) {
+            ExecuteInitComm(inst);
+          } else if constexpr (std::is_same_v<T, UseComm>) {
+            ExecuteUseComm(inst);
+          } else if constexpr (std::is_same_v<T, Copy> ||
+                               std::is_same_v<T, Send> ||
+                               std::is_same_v<T, Receive>) {
+            if (!group_started) {
+              NCCL_CHECK(ncclGroupStart());
+              group_started = true;
+              ops_in_group = 0;
+
+              // Record start event on GPU timeline
+              cudaEvent_t start_event;
+              CUDA_CHECK(cudaEventCreate(&start_event));
+              CUDA_CHECK(cudaEventRecord(start_event, stream_));
+              event_states.push_back({start_event, nullptr, 0});
+            }
+            ops_in_group++;
+
+            if constexpr (std::is_same_v<T, Copy>) {
+              ExecuteCopy(inst);
+            } else if constexpr (std::is_same_v<T, Send>) {
+              ExecuteSend(inst);
+            } else {
+              ExecuteReceive(inst);
+            }
+          } else if constexpr (std::is_same_v<T, Barrier>) {
+            if (group_started) {
+              NCCL_CHECK(ncclGroupEnd());
+
+              // Record end event before sync
+              cudaEvent_t end_event;
+              CUDA_CHECK(cudaEventCreate(&end_event));
+              CUDA_CHECK(cudaEventRecord(end_event, stream_));
+              event_states.back().end_event = end_event;
+              event_states.back().ops_in_group = ops_in_group;
+
+              CUDA_CHECK(cudaStreamSynchronize(stream_));
+
+              timings.push_back({group_index, 0.0, ops_in_group});
+              group_started = false;
+              group_index++;
+            }
+          }
+        },
+        instruction.instr);
   }
 
+  // Handle trailing group (no final Barrier)
   if (group_started) {
     NCCL_CHECK(ncclGroupEnd());
+
+    cudaEvent_t end_event;
+    CUDA_CHECK(cudaEventCreate(&end_event));
+    CUDA_CHECK(cudaEventRecord(end_event, stream_));
+    event_states.back().end_event = end_event;
+    event_states.back().ops_in_group = ops_in_group;
+
     CUDA_CHECK(cudaStreamSynchronize(stream_));
+    timings.push_back({group_index, 0.0, ops_in_group});
   }
-}
 
-void NCCLWorker::ExecuteInstruction(const Instruction& instruction,
-                                    bool& group_started) {
-  std::visit(
-      [this, &group_started](const auto& inst) {
-        using T = std::decay_t<decltype(inst)>;
+  // Compute elapsed times from CUDA event pairs
+  for (std::size_t i = 0; i < event_states.size(); ++i) {
+    float ms = 0.0f;
+    CUDA_CHECK(cudaEventElapsedTime(&ms, event_states[i].start_event,
+                                    event_states[i].end_event));
+    timings[i].elapsed_ms = static_cast<double>(ms);
+    CUDA_CHECK(cudaEventDestroy(event_states[i].start_event));
+    CUDA_CHECK(cudaEventDestroy(event_states[i].end_event));
+  }
 
-        if constexpr (std::is_same_v<T, InitComm>) {
-          ExecuteInitComm(inst);
-        } else if constexpr (std::is_same_v<T, UseComm>) {
-          ExecuteUseComm(inst);
-        } else if constexpr (std::is_same_v<T, Copy>) {
-          if (!group_started) {
-            NCCL_CHECK(ncclGroupStart());
-            group_started = true;
-          }
-          ExecuteCopy(inst);
-        } else if constexpr (std::is_same_v<T, Send>) {
-          if (!group_started) {
-            NCCL_CHECK(ncclGroupStart());
-            group_started = true;
-          }
-          ExecuteSend(inst);
-        } else if constexpr (std::is_same_v<T, Receive>) {
-          if (!group_started) {
-            NCCL_CHECK(ncclGroupStart());
-            group_started = true;
-          }
-          ExecuteReceive(inst);
-        } else if constexpr (std::is_same_v<T, Barrier>) {
-          if (group_started) {
-            NCCL_CHECK(ncclGroupEnd());
-            CUDA_CHECK(cudaStreamSynchronize(stream_));
-            group_started = false;
-          }
-        }
-      },
-      instruction.instr);
+  auto t_end = std::chrono::high_resolution_clock::now();
+  double total_ms =
+      std::chrono::duration<double, std::milli>(t_end - t_start).count();
+
+  // Submit metrics if sink is available
+  if (metrics_sink_ && metrics_sink_->IsEnabled()) {
+    setu::telemetry::NCCLWorkerMetrics wm;
+    wm.copy_op_id = current_copy_op_id_;
+    wm.node_id = node_id_;
+    wm.device_rank = device_.LocalDeviceIndex();
+    wm.group_timings = std::move(timings);
+    wm.total_execute_ms = total_ms;
+    metrics_sink_->Submit(setu::telemetry::MetricsMessage{wm});
+  }
 }
 
 //==============================================================================
@@ -128,13 +179,18 @@ void NCCLWorker::ExecuteInitComm(const InitComm& inst) {
   auto part = Participant(node_id_, device_);
   const std::int32_t rank = inst.participant_to_rank.at(part);
 
+  auto t0 = std::chrono::steady_clock::now();
   ncclComm_t comm;
   NCCL_CHECK(ncclCommInitRank(&comm, num_ranks, inst.comm_id, rank));
+  auto dt = std::chrono::duration_cast<std::chrono::milliseconds>(
+                std::chrono::steady_clock::now() - t0)
+                .count();
 
   comm_cache_[key] = CommCacheEntry{.nccl_comm = comm};
 
   active_comm_key_ = key;
-  LOG_DEBUG("InitComm complete: {} ranks, this rank={}", num_ranks, rank);
+  LOG_INFO("InitComm[{}]: ncclCommInitRank took {}ms, {} ranks, this rank={}",
+           device_, dt, num_ranks, rank);
 }
 
 void NCCLWorker::ExecuteUseComm(const UseComm& inst) {

--- a/csrc/setu/node_manager/worker/NCCLWorker.h
+++ b/csrc/setu/node_manager/worker/NCCLWorker.h
@@ -28,6 +28,7 @@
 #include "node_manager/worker/Worker.h"
 #include "planner/Constants.h"
 #include "planner/ir/llc/Instruction.h"
+#include "telemetry/NCCLWorkerMetrics.h"
 //==============================================================================
 namespace setu::node_manager::worker {
 //==============================================================================
@@ -63,8 +64,6 @@ class NCCLWorker : public Worker {
       const RegisterRef& ref) const override;
 
  private:
-  void ExecuteInstruction(const Instruction& instruction, bool& group_started);
-
   void ExecuteInitComm(const InitComm& inst);
   void ExecuteUseComm(const UseComm& inst);
   void ExecuteCopy(const Copy& inst);
@@ -77,6 +76,13 @@ class NCCLWorker : public Worker {
 
   struct CommCacheEntry {
     ncclComm_t nccl_comm;
+  };
+
+  /// @brief Holds CUDA events for measuring group timing.
+  struct GroupTimingState {
+    cudaEvent_t start_event;
+    cudaEvent_t end_event;
+    std::size_t ops_in_group;
   };
 
   std::unordered_map<std::string, CommCacheEntry> comm_cache_;

--- a/csrc/setu/node_manager/worker/Worker.cpp
+++ b/csrc/setu/node_manager/worker/Worker.cpp
@@ -79,6 +79,10 @@ void Worker::CloseZmqSockets() {
   if (socket_) socket_->close();
 }
 
+void Worker::SetMetricsSink(MetricsSinkPtr sink) {
+  metrics_sink_ = std::move(sink);
+}
+
 void Worker::WorkerLoop() {
   LOG_DEBUG("WorkerLoop started on device {}", device_);
 
@@ -86,10 +90,19 @@ void Worker::WorkerLoop() {
   while (worker_running_) {
     // Receive ExecuteProgramRequest from NodeAgent
     auto request = Comm::Recv<ExecuteProgramRequest>(socket_);
+    current_copy_op_id_ = request.copy_op_id;
     const auto& program = request.program;
+
+    auto t0 = std::chrono::steady_clock::now();
 
     // Execute each instruction in the program
     this->Execute(program);
+
+    auto dt = std::chrono::duration_cast<std::chrono::microseconds>(
+                  std::chrono::steady_clock::now() - t0)
+                  .count();
+    LOG_INFO("Worker[{}]: Execute took {}us, {} instructions", device_, dt,
+             program.size());
 
     // Send acknowledgment back to NodeAgent
     ExecuteProgramResponse response(RequestId{}, ErrorCode::kSuccess);

--- a/csrc/setu/node_manager/worker/Worker.h
+++ b/csrc/setu/node_manager/worker/Worker.h
@@ -18,14 +18,17 @@
 //==============================================================================
 #include "commons/StdCommon.h"
 #include "commons/Types.h"
+//==============================================================================
 #include "commons/datatypes/Device.h"
 #include "commons/enums/Enums.h"
 #include "commons/utils/ZmqHelper.h"
 #include "planner/ir/llc/Instruction.h"
 #include "planner/ir/ref/RegisterRef.h"
+#include "telemetry/MetricsSink.h"
 //==============================================================================
 namespace setu::node_manager::worker {
 //==============================================================================
+using setu::commons::CopyOperationId;
 using setu::commons::DevicePtr;
 using setu::commons::NodeId;
 using setu::commons::datatypes::Device;
@@ -34,6 +37,7 @@ using setu::commons::utils::ZmqContextPtr;
 using setu::commons::utils::ZmqSocketPtr;
 using setu::planner::ir::llc::Program;
 using setu::planner::ir::ref::RegisterRef;
+using setu::telemetry::MetricsSinkPtr;
 //==============================================================================
 class Worker {
  public:
@@ -56,6 +60,9 @@ class Worker {
   [[nodiscard]] virtual DevicePtr ResolveRegister(
       const RegisterRef& ref) const = 0;
 
+  /// Set the metrics sink for telemetry submission.
+  void SetMetricsSink(MetricsSinkPtr sink);
+
  protected:
   void InitZmqSockets();
   void CloseZmqSockets();
@@ -72,6 +79,9 @@ class Worker {
   std::atomic<bool> worker_running_;
 
   std::thread worker_thread_;
+
+  CopyOperationId current_copy_op_id_;
+  MetricsSinkPtr metrics_sink_;
 };
 //==============================================================================
 }  // namespace setu::node_manager::worker

--- a/csrc/setu/planner/Planner.cpp
+++ b/csrc/setu/planner/Planner.cpp
@@ -27,11 +27,47 @@ Planner::Planner(targets::BackendPtr backend,
   ASSERT_VALID_POINTER_ARGUMENT(backend_);
 }
 //==============================================================================
-Plan Planner::Compile(const CopySpec& spec, MetaStore& metastore,
-                      const HintStore& hints) {
+CompileResult Planner::Compile(const CopySpec& spec, MetaStore& metastore,
+                               const HintStore& hints,
+                               CopyOperationId copy_op_id) {
+  setu::telemetry::CompilationMetrics cm;
+  cm.copy_op_id = copy_op_id;
+
+  auto t_total = std::chrono::high_resolution_clock::now();
+
+  // Stage 1: CopySpec -> CIR
+  auto t0 = std::chrono::high_resolution_clock::now();
   auto cir = planner::passes::CopySpecToCIR::Run(spec, metastore);
-  cir = pass_manager_->Run(std::move(cir), hints);
-  return backend_->Run(cir);
+  double stage1_ms = std::chrono::duration<double, std::milli>(
+                         std::chrono::high_resolution_clock::now() - t0)
+                         .count();
+  cm.pass_timings.push_back({"CopySpecToCIR", stage1_ms});
+
+  // Stage 2: Optimization passes (timed individually)
+  auto [optimized_cir, pass_timings] =
+      pass_manager_->RunTimed(std::move(cir), hints);
+  cm.pass_timings.insert(cm.pass_timings.end(), pass_timings.begin(),
+                         pass_timings.end());
+
+  // Stage 3: Backend lowering
+  t0 = std::chrono::high_resolution_clock::now();
+  Plan plan = backend_->Run(optimized_cir);
+  double stage3_ms = std::chrono::duration<double, std::milli>(
+                         std::chrono::high_resolution_clock::now() - t0)
+                         .count();
+  cm.pass_timings.push_back({"Backend", stage3_ms});
+
+  cm.total_compile_time_ms =
+      std::chrono::duration<double, std::milli>(
+          std::chrono::high_resolution_clock::now() - t_total)
+          .count();
+  cm.num_participants = static_cast<std::uint32_t>(plan.participants.size());
+  for (const auto& [p, prog] : plan.program) {
+    cm.participant_instruction_counts.emplace_back(
+        p.ToString(), static_cast<std::uint32_t>(prog.size()));
+  }
+
+  return {std::move(plan), std::move(cm)};
 }
 //==============================================================================
 }  // namespace setu::planner

--- a/csrc/setu/planner/Planner.h
+++ b/csrc/setu/planner/Planner.h
@@ -17,6 +17,7 @@
 #pragma once
 //==============================================================================
 #include "commons/StdCommon.h"
+#include "commons/Types.h"
 //==============================================================================
 #include "commons/datatypes/CopySpec.h"
 #include "metastore/MetaStore.h"
@@ -24,20 +25,31 @@
 #include "planner/hints/HintStore.h"
 #include "planner/passes/PassManager.h"
 #include "planner/targets/backend.h"
+#include "telemetry/MetricsData.h"
 //==============================================================================
 namespace setu::planner {
 //==============================================================================
 
+using setu::commons::CopyOperationId;
 using setu::commons::datatypes::CopySpec;
 using setu::metastore::MetaStore;
 using setu::planner::hints::HintStore;
 using setu::planner::ir::llc::Program;
 
+/// @brief Result of Planner::Compile, containing the Plan and compilation
+/// metrics.
+struct CompileResult {
+  Plan plan;
+  setu::telemetry::CompilationMetrics metrics;
+};
+
 class Planner {
  public:
   Planner(targets::BackendPtr backend, passes::PassManagerPtr pass_manager);
-  [[nodiscard]] Plan Compile(const CopySpec& spec, MetaStore& metastore,
-                             const HintStore& hints);
+  [[nodiscard]] CompileResult Compile(const CopySpec& spec,
+                                      MetaStore& metastore,
+                                      const HintStore& hints,
+                                      CopyOperationId copy_op_id);
 
  private:
   targets::BackendPtr backend_;

--- a/csrc/setu/planner/Pybind.cpp
+++ b/csrc/setu/planner/Pybind.cpp
@@ -33,6 +33,7 @@
 //==============================================================================
 namespace setu::planner {
 //==============================================================================
+using setu::commons::CopyOperationId;
 using setu::commons::NodeId;
 using setu::commons::datatypes::Device;
 //==============================================================================
@@ -90,7 +91,8 @@ void InitPlannerClassPybind(py::module_& m) {
           "compile",
           [](Planner& self, const CopySpec& spec, MetaStore& metastore) {
             hints::HintStore empty_hints;
-            return self.Compile(spec, metastore, empty_hints);
+            CopyOperationId dummy_id{};
+            return self.Compile(spec, metastore, empty_hints, dummy_id).plan;
           },
           py::arg("spec"), py::arg("metastore"),
           "Compile a copy spec into a plan (with no hints)");

--- a/csrc/setu/planner/passes/PassManager.cpp
+++ b/csrc/setu/planner/passes/PassManager.cpp
@@ -34,6 +34,22 @@ cir::Program PassManager::Run(cir::Program program,
   return program;
 }
 //==============================================================================
+std::pair<cir::Program, std::vector<setu::telemetry::PassTiming>>
+PassManager::RunTimed(cir::Program program, const HintStore& hints) const {
+  std::vector<setu::telemetry::PassTiming> timings;
+  timings.reserve(passes_.size());
+  for (const auto& pass : passes_) {
+    auto t0 = std::chrono::high_resolution_clock::now();
+    program = pass->Run(std::move(program), hints);
+    double elapsed_ms = std::chrono::duration<double, std::milli>(
+                            std::chrono::high_resolution_clock::now() - t0)
+                            .count();
+    timings.push_back({pass->Name(), elapsed_ms});
+    LOG_DEBUG("After pass '{}': {}", pass->Name(), program.Dump());
+  }
+  return {std::move(program), std::move(timings)};
+}
+//==============================================================================
 std::size_t PassManager::NumPasses() const { return passes_.size(); }
 //==============================================================================
 }  // namespace setu::planner::passes

--- a/csrc/setu/planner/passes/PassManager.h
+++ b/csrc/setu/planner/passes/PassManager.h
@@ -20,6 +20,7 @@
 //==============================================================================
 #include "commons/ClassTraits.h"
 #include "planner/passes/Pass.h"
+#include "telemetry/MetricsData.h"
 //==============================================================================
 namespace setu::planner::passes {
 //==============================================================================
@@ -30,6 +31,13 @@ class PassManager : public setu::commons::NonCopyable {
   void AddPass(PassPtr pass);
   [[nodiscard]] cir::Program Run(cir::Program program,
                                  const HintStore& hints) const;
+
+  /// @brief Run all passes with per-pass timing.
+  /// Returns the transformed program and a vector of PassTiming records.
+  [[nodiscard]] std::pair<cir::Program,
+                          std::vector<setu::telemetry::PassTiming>>
+  RunTimed(cir::Program program, const HintStore& hints) const;
+
   [[nodiscard]] std::size_t NumPasses() const;
 
  private:

--- a/csrc/setu/telemetry/MetricsData.h
+++ b/csrc/setu/telemetry/MetricsData.h
@@ -1,0 +1,132 @@
+//==============================================================================
+// Copyright (c) 2025 Vajra Team; Georgia Institute of Technology; Microsoft
+// Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//==============================================================================
+#pragma once
+//==============================================================================
+#include "commons/StdCommon.h"
+#include "commons/Types.h"
+//==============================================================================
+#include "commons/utils/Serialization.h"
+//==============================================================================
+namespace setu::telemetry {
+//==============================================================================
+using setu::commons::BinaryBuffer;
+using setu::commons::BinaryRange;
+using setu::commons::CopyOperationId;
+using setu::commons::utils::BinaryReader;
+using setu::commons::utils::BinaryWriter;
+//==============================================================================
+
+/// @brief Timing for a single compiler pass.
+struct PassTiming {
+  std::string pass_name;
+  double elapsed_ms;
+
+  void Serialize(BinaryBuffer& buffer) const {
+    BinaryWriter writer(buffer);
+    writer.WriteFields(pass_name, elapsed_ms);
+  }
+
+  static PassTiming Deserialize(const BinaryRange& range) {
+    BinaryReader reader(range);
+    auto [name, ms] = reader.ReadFields<std::string, double>();
+    return PassTiming{std::move(name), ms};
+  }
+};
+
+/// @brief Metrics from the Planner::Compile stage (backend-agnostic).
+struct CompilationMetrics {
+  CopyOperationId copy_op_id;
+  double total_compile_time_ms;
+  std::vector<PassTiming> pass_timings;
+  std::uint32_t num_participants;
+  std::vector<std::pair<std::string, std::uint32_t>>
+      participant_instruction_counts;
+
+  void Serialize(BinaryBuffer& buffer) const {
+    BinaryWriter writer(buffer);
+    writer.WriteFields(copy_op_id, total_compile_time_ms, pass_timings,
+                       num_participants);
+    // Serialize vector of pairs manually
+    writer.Write<std::uint32_t>(
+        static_cast<std::uint32_t>(participant_instruction_counts.size()));
+    for (const auto& [name, count] : participant_instruction_counts) {
+      writer.Write(name);
+      writer.Write(count);
+    }
+  }
+
+  static CompilationMetrics Deserialize(const BinaryRange& range) {
+    BinaryReader reader(range);
+    auto [id, total_ms, timings, num_parts] =
+        reader.ReadFields<CopyOperationId, double, std::vector<PassTiming>,
+                          std::uint32_t>();
+
+    auto num_entries = reader.Read<std::uint32_t>();
+    std::vector<std::pair<std::string, std::uint32_t>> counts;
+    counts.reserve(num_entries);
+    for (std::uint32_t i = 0; i < num_entries; ++i) {
+      auto name = reader.Read<std::string>();
+      auto count = reader.Read<std::uint32_t>();
+      counts.emplace_back(std::move(name), count);
+    }
+
+    return CompilationMetrics{id, total_ms, std::move(timings), num_parts,
+                              std::move(counts)};
+  }
+};
+
+/// @brief End-to-end timing for a complete copy operation.
+struct E2EMetrics {
+  CopyOperationId copy_op_id;
+  double e2e_time_ms;
+
+  void Serialize(BinaryBuffer& buffer) const {
+    BinaryWriter writer(buffer);
+    writer.WriteFields(copy_op_id, e2e_time_ms);
+  }
+
+  static E2EMetrics Deserialize(const BinaryRange& range) {
+    BinaryReader reader(range);
+    auto [id, ms] = reader.ReadFields<CopyOperationId, double>();
+    return E2EMetrics{id, ms};
+  }
+};
+
+//==============================================================================
+}  // namespace setu::telemetry
+//==============================================================================
+// Forward-declare NCCLWorkerMetrics so the variant can reference it.
+namespace setu::telemetry {
+struct NCCLWorkerMetrics;
+}
+//==============================================================================
+namespace setu::telemetry {
+//==============================================================================
+
+/// @brief Union of all metrics message types.
+///
+/// Each backend adds its own worker metrics type to this variant.
+/// The variant index is serialized as a uint32 prefix.
+/// Index 0: NCCLWorkerMetrics (NCCL backend worker metrics)
+/// Index 1: CompilationMetrics (backend-agnostic compilation timing)
+/// Index 2: E2EMetrics (backend-agnostic end-to-end timing)
+using MetricsMessage =
+    std::variant<NCCLWorkerMetrics, CompilationMetrics, E2EMetrics>;
+
+//==============================================================================
+}  // namespace setu::telemetry
+//==============================================================================

--- a/csrc/setu/telemetry/MetricsSink.cpp
+++ b/csrc/setu/telemetry/MetricsSink.cpp
@@ -1,0 +1,66 @@
+//==============================================================================
+// Copyright (c) 2025 Vajra Team; Georgia Institute of Technology; Microsoft
+// Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//==============================================================================
+#include "telemetry/MetricsSink.h"
+//==============================================================================
+#include "commons/Logging.h"
+//==============================================================================
+namespace setu::telemetry {
+//==============================================================================
+
+MetricsSink::MetricsSink(ZmqContextPtr zmq_context, std::string server_endpoint)
+    : endpoint_(std::move(server_endpoint)) {
+  ASSERT_VALID_POINTER_ARGUMENT(zmq_context);
+
+  socket_ =
+      std::make_shared<zmq::socket_t>(*zmq_context, zmq::socket_type::push);
+  socket_->set(zmq::sockopt::linger, 0);
+  socket_->set(zmq::sockopt::sndhwm, 1000);
+  socket_->connect(endpoint_);
+
+  LOG_DEBUG("MetricsSink connected to {}", endpoint_);
+}
+
+void MetricsSink::Submit(const MetricsMessage& message) {
+  if (!enabled_.load(std::memory_order_relaxed)) {
+    return;
+  }
+
+  // Serialize the variant using BinaryWriter
+  BinaryBuffer buffer;
+  BinaryWriter writer(buffer);
+  writer.Write(message);
+
+  zmq::message_t zmq_msg(buffer.data(), buffer.size());
+
+  // Non-blocking send: silently drop if server is unavailable
+  auto result = socket_->send(std::move(zmq_msg), zmq::send_flags::dontwait);
+  if (!result.has_value()) {
+    LOG_DEBUG("MetricsSink: message dropped (server unavailable)");
+  }
+}
+
+void MetricsSink::SetEnabled(bool enabled) {
+  enabled_.store(enabled, std::memory_order_relaxed);
+}
+
+bool MetricsSink::IsEnabled() const {
+  return enabled_.load(std::memory_order_relaxed);
+}
+
+//==============================================================================
+}  // namespace setu::telemetry
+//==============================================================================

--- a/csrc/setu/telemetry/MetricsSink.h
+++ b/csrc/setu/telemetry/MetricsSink.h
@@ -18,48 +18,39 @@
 //==============================================================================
 #include "commons/StdCommon.h"
 //==============================================================================
-#include "coordinator/Types.h"
-#include "metastore/MetaStore.h"
-#include "planner/Planner.h"
-#include "telemetry/MetricsSink.h"
+#include "commons/utils/ZmqHelper.h"
+#include "telemetry/MetricsData.h"
+#include "telemetry/NCCLWorkerMetrics.h"
 //==============================================================================
-namespace setu::coordinator {
+namespace setu::telemetry {
 //==============================================================================
-using setu::metastore::MetaStore;
-using setu::planner::Planner;
+using setu::commons::utils::ZmqContextPtr;
+using setu::commons::utils::ZmqSocketPtr;
 //==============================================================================
 
-/// @brief Compiles CopySpecs into execution plans and dispatches them to
-/// NodeAgents.
+/// @brief Non-blocking fire-and-forget metrics submitter over ZMQ PUSH.
 ///
-/// Executor runs on a dedicated thread, pulling PlannerTasks from the planner
-/// queue. For each task it compiles a Plan, fragments it per-node, and sends
-/// ExecuteRequests through the outbox queue.
-class Executor {
+/// Each thread that needs to submit metrics should create its own
+/// MetricsSink instance (ZMQ sockets are not thread-safe).
+/// If the server is down, messages are silently dropped.
+class MetricsSink {
  public:
-  Executor(Queue<PlannerTask>& planner_queue,
-           Queue<OutboxMessage>& outbox_queue, MetaStore& metastore,
-           Planner& planner, OutboxNotifyFn outbox_notify,
-           setu::telemetry::MetricsSinkPtr metrics_sink);
+  MetricsSink(ZmqContextPtr zmq_context, std::string server_endpoint);
 
-  void Start();
-  void Stop();
+  /// @brief Serialize and send a MetricsMessage. Non-blocking.
+  void Submit(const MetricsMessage& message);
+
+  void SetEnabled(bool enabled);
+  [[nodiscard]] bool IsEnabled() const;
 
  private:
-  void Loop();
-
-  void PushOutbox(OutboxMessage msg);
-
-  Queue<PlannerTask>& planner_queue_;
-  Queue<OutboxMessage>& outbox_queue_;
-  MetaStore& metastore_;
-  Planner& planner_;
-  OutboxNotifyFn outbox_notify_;
-  setu::telemetry::MetricsSinkPtr metrics_sink_;
-
-  std::thread thread_;
-  std::atomic<bool> running_{false};
+  ZmqSocketPtr socket_;
+  std::string endpoint_;
+  std::atomic<bool> enabled_{true};
 };
+
+using MetricsSinkPtr = std::shared_ptr<MetricsSink>;
+
 //==============================================================================
-}  // namespace setu::coordinator
+}  // namespace setu::telemetry
 //==============================================================================

--- a/csrc/setu/telemetry/NCCLWorkerMetrics.h
+++ b/csrc/setu/telemetry/NCCLWorkerMetrics.h
@@ -20,59 +20,61 @@
 #include "commons/Types.h"
 //==============================================================================
 #include "commons/utils/Serialization.h"
-#include "messaging/BaseRequest.h"
-#include "planner/ir/llc/Instruction.h"
 //==============================================================================
-namespace setu::commons::messages {
+namespace setu::telemetry {
 //==============================================================================
+using setu::commons::BinaryBuffer;
+using setu::commons::BinaryRange;
 using setu::commons::CopyOperationId;
-using setu::commons::utils::BinaryBuffer;
-using setu::commons::utils::BinaryRange;
+using setu::commons::DeviceRank;
+using setu::commons::NodeId;
 using setu::commons::utils::BinaryReader;
 using setu::commons::utils::BinaryWriter;
-using setu::planner::ir::llc::Program;
 //==============================================================================
 
-struct ExecuteProgramRequest : public BaseRequest {
-  /// @brief Constructs a request with auto-generated request ID.
-  ExecuteProgramRequest(CopyOperationId copy_op_id_param, Program program_param)
-      : BaseRequest(),
-        copy_op_id(copy_op_id_param),
-        program(std::move(program_param)) {}
-
-  /// @brief Constructs a request with explicit request ID (for
-  /// deserialization).
-  ExecuteProgramRequest(RequestId request_id_param,
-                        CopyOperationId copy_op_id_param, Program program_param)
-      : BaseRequest(request_id_param),
-        copy_op_id(copy_op_id_param),
-        program(std::move(program_param)) {}
-
-  [[nodiscard]] std::string ToString() const {
-    return std::format(
-        "ExecuteProgramRequest(request_id={}, copy_op_id={}, "
-        "program_size={})",
-        request_id, copy_op_id, program.size());
-  }
+/// @brief Timing for a single NCCL group (between barriers).
+struct NCCLGroupTiming {
+  std::uint32_t group_index;
+  double elapsed_ms;    // GPU-measured via CUDA events
+  std::size_t num_ops;  // number of Copy/Send/Receive in this group
 
   void Serialize(BinaryBuffer& buffer) const {
     BinaryWriter writer(buffer);
-    writer.WriteFields(request_id, copy_op_id, program);
+    writer.WriteFields(group_index, elapsed_ms,
+                       static_cast<std::uint64_t>(num_ops));
   }
 
-  static ExecuteProgramRequest Deserialize(const BinaryRange& range) {
+  static NCCLGroupTiming Deserialize(const BinaryRange& range) {
     BinaryReader reader(range);
-    auto [request_id_val, copy_op_id_val, program_val] =
-        reader.ReadFields<RequestId, CopyOperationId, Program>();
-    return ExecuteProgramRequest(request_id_val, copy_op_id_val,
-                                 std::move(program_val));
+    auto [idx, ms, ops] =
+        reader.ReadFields<std::uint32_t, double, std::uint64_t>();
+    return NCCLGroupTiming{idx, ms, static_cast<std::size_t>(ops)};
+  }
+};
+
+/// @brief NCCL-specific worker metrics: per-group GPU timing.
+struct NCCLWorkerMetrics {
+  CopyOperationId copy_op_id;
+  NodeId node_id;
+  DeviceRank device_rank;
+  std::vector<NCCLGroupTiming> group_timings;
+  double total_execute_ms;  // wall-clock for entire Execute()
+
+  void Serialize(BinaryBuffer& buffer) const {
+    BinaryWriter writer(buffer);
+    writer.WriteFields(copy_op_id, node_id, device_rank, group_timings,
+                       total_execute_ms);
   }
 
-  const CopyOperationId copy_op_id;
-  const Program program;
+  static NCCLWorkerMetrics Deserialize(const BinaryRange& range) {
+    BinaryReader reader(range);
+    auto [id, nid, rank, timings, total] =
+        reader.ReadFields<CopyOperationId, NodeId, DeviceRank,
+                          std::vector<NCCLGroupTiming>, double>();
+    return NCCLWorkerMetrics{id, nid, rank, std::move(timings), total};
+  }
 };
-using ExecuteProgramRequestPtr = std::shared_ptr<ExecuteProgramRequest>;
 
 //==============================================================================
-}  // namespace setu::commons::messages
+}  // namespace setu::telemetry
 //==============================================================================

--- a/setu/telemetry/__init__.py
+++ b/setu/telemetry/__init__.py
@@ -1,0 +1,5 @@
+"""Setu telemetry: metrics collection, aggregation, and reporting."""
+
+from setu.telemetry.server import CopySpecReport, MetricsServer
+
+__all__ = ["MetricsServer", "CopySpecReport"]

--- a/setu/telemetry/__main__.py
+++ b/setu/telemetry/__main__.py
@@ -1,0 +1,53 @@
+"""Standalone entry point: python -m setu.telemetry"""
+
+import argparse
+import signal
+import sys
+
+from setu.logger import init_logger
+from setu.telemetry.server import MetricsServer
+from setu.telemetry.sinks.csv_sink import CSVReportSink
+
+logger = init_logger(__name__)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Setu telemetry metrics server",
+    )
+    parser.add_argument(
+        "--endpoint",
+        default="tcp://*:9999",
+        help="ZMQ PULL bind endpoint (default: tcp://*:9999)",
+    )
+    parser.add_argument(
+        "--output-dir",
+        default="./telemetry_results",
+        help="Directory for CSV report output (default: ./telemetry_results)",
+    )
+    args = parser.parse_args()
+
+    csv_sink = CSVReportSink(args.output_dir)
+    server = MetricsServer(endpoint=args.endpoint, sinks=[csv_sink])
+
+    def shutdown(signum, frame):
+        logger.info("Received signal %d, shutting down...", signum)
+        server.stop()
+        sys.exit(0)
+
+    signal.signal(signal.SIGINT, shutdown)
+    signal.signal(signal.SIGTERM, shutdown)
+
+    server.start()
+    logger.info(
+        "Telemetry server running (endpoint=%s, output_dir=%s). Press Ctrl+C to stop.",
+        args.endpoint,
+        args.output_dir,
+    )
+
+    # Block until signal
+    signal.pause()
+
+
+if __name__ == "__main__":
+    main()

--- a/setu/telemetry/deserialize.py
+++ b/setu/telemetry/deserialize.py
@@ -1,0 +1,201 @@
+"""Binary deserializer matching C++ BinaryWriter format.
+
+Setu serialization conventions:
+- Little-endian for all integers and floats.
+- Strings: uint32 length prefix + raw bytes (UTF-8).
+- Vectors: uint32 count prefix + elements.
+- UUIDs: 16 raw bytes (boost::uuids::uuid layout).
+- Variants: uint32 index prefix + active alternative value.
+- Serializable objects: uint32 byte-size prefix + serialized payload.
+"""
+
+import struct
+import uuid
+from dataclasses import dataclass
+from typing import List, Tuple
+
+
+class BinaryReader:
+    """Forward-only binary reader matching C++ BinaryWriter format."""
+
+    def __init__(self, data: bytes) -> None:
+        self._data = data
+        self._pos = 0
+
+    def _read_raw(self, n: int) -> bytes:
+        end = self._pos + n
+        if end > len(self._data):
+            raise ValueError(
+                f"BinaryReader overflow: need {n} bytes at offset {self._pos}, "
+                f"have {len(self._data) - self._pos}"
+            )
+        chunk = self._data[self._pos : end]
+        self._pos = end
+        return chunk
+
+    def read_uint32(self) -> int:
+        return struct.unpack("<I", self._read_raw(4))[0]
+
+    def read_uint64(self) -> int:
+        return struct.unpack("<Q", self._read_raw(8))[0]
+
+    def read_int32(self) -> int:
+        return struct.unpack("<i", self._read_raw(4))[0]
+
+    def read_double(self) -> float:
+        return struct.unpack("<d", self._read_raw(8))[0]
+
+    def read_string(self) -> str:
+        length = self.read_uint32()
+        return self._read_raw(length).decode("utf-8")
+
+    def read_uuid(self) -> uuid.UUID:
+        raw = self._read_raw(16)
+        return uuid.UUID(bytes=raw)
+
+    def remaining(self) -> int:
+        return len(self._data) - self._pos
+
+
+# ---------------------------------------------------------------------------
+# Deserialized metric types (mirrors C++ structs)
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class PassTiming:
+    pass_name: str
+    elapsed_ms: float
+
+
+@dataclass
+class NCCLGroupTiming:
+    group_index: int
+    elapsed_ms: float
+    num_ops: int
+
+
+@dataclass
+class NCCLWorkerMetricsRecord:
+    copy_op_id: uuid.UUID
+    node_id: uuid.UUID
+    device_rank: int
+    group_timings: List[NCCLGroupTiming]
+    total_execute_ms: float
+
+
+@dataclass
+class CompilationMetricsRecord:
+    copy_op_id: uuid.UUID
+    total_compile_time_ms: float
+    pass_timings: List[PassTiming]
+    num_participants: int
+    participant_instruction_counts: List[Tuple[str, int]]
+
+
+@dataclass
+class E2EMetricsRecord:
+    copy_op_id: uuid.UUID
+    e2e_time_ms: float
+
+
+# Variant index mapping (must match C++ MetricsMessage variant order)
+_VARIANT_INDEX_NCCL_WORKER = 0
+_VARIANT_INDEX_COMPILATION = 1
+_VARIANT_INDEX_E2E = 2
+
+
+def _read_pass_timing(reader: BinaryReader) -> PassTiming:
+    """Read a PassTiming (Serializable: uint32 size prefix + payload)."""
+    _size = reader.read_uint32()
+    name = reader.read_string()
+    ms = reader.read_double()
+    return PassTiming(pass_name=name, elapsed_ms=ms)
+
+
+def _read_nccl_group_timing(reader: BinaryReader) -> NCCLGroupTiming:
+    """Read a NCCLGroupTiming (Serializable: uint32 size prefix + payload)."""
+    _size = reader.read_uint32()
+    idx = reader.read_uint32()
+    ms = reader.read_double()
+    ops = reader.read_uint64()
+    return NCCLGroupTiming(group_index=idx, elapsed_ms=ms, num_ops=ops)
+
+
+def _read_nccl_worker_metrics(reader: BinaryReader) -> NCCLWorkerMetricsRecord:
+    """Read NCCLWorkerMetrics (Serializable: uint32 size prefix + payload)."""
+    _size = reader.read_uint32()
+    copy_op_id = reader.read_uuid()
+    node_id = reader.read_uuid()
+    device_rank = reader.read_int32()
+
+    num_timings = reader.read_uint32()
+    timings = [_read_nccl_group_timing(reader) for _ in range(num_timings)]
+
+    total_ms = reader.read_double()
+    return NCCLWorkerMetricsRecord(
+        copy_op_id=copy_op_id,
+        node_id=node_id,
+        device_rank=device_rank,
+        group_timings=timings,
+        total_execute_ms=total_ms,
+    )
+
+
+def _read_compilation_metrics(reader: BinaryReader) -> CompilationMetricsRecord:
+    """Read CompilationMetrics (Serializable: uint32 size prefix + payload)."""
+    _size = reader.read_uint32()
+    copy_op_id = reader.read_uuid()
+    total_ms = reader.read_double()
+
+    num_timings = reader.read_uint32()
+    timings = [_read_pass_timing(reader) for _ in range(num_timings)]
+
+    num_participants = reader.read_uint32()
+
+    num_entries = reader.read_uint32()
+    counts = []
+    for _ in range(num_entries):
+        name = reader.read_string()
+        count = reader.read_uint32()
+        counts.append((name, count))
+
+    return CompilationMetricsRecord(
+        copy_op_id=copy_op_id,
+        total_compile_time_ms=total_ms,
+        pass_timings=timings,
+        num_participants=num_participants,
+        participant_instruction_counts=counts,
+    )
+
+
+def _read_e2e_metrics(reader: BinaryReader) -> E2EMetricsRecord:
+    """Read E2EMetrics (Serializable: uint32 size prefix + payload)."""
+    _size = reader.read_uint32()
+    copy_op_id = reader.read_uuid()
+    ms = reader.read_double()
+    return E2EMetricsRecord(copy_op_id=copy_op_id, e2e_time_ms=ms)
+
+
+# Maps variant index to reader function
+_VARIANT_READERS = {
+    _VARIANT_INDEX_NCCL_WORKER: _read_nccl_worker_metrics,
+    _VARIANT_INDEX_COMPILATION: _read_compilation_metrics,
+    _VARIANT_INDEX_E2E: _read_e2e_metrics,
+}
+
+
+def deserialize_metrics_message(data: bytes):
+    """Deserialize a MetricsMessage from raw bytes.
+
+    Returns one of: NCCLWorkerMetricsRecord, CompilationMetricsRecord,
+    E2EMetricsRecord.
+    """
+    reader = BinaryReader(data)
+    variant_index = reader.read_uint32()
+
+    reader_fn = _VARIANT_READERS.get(variant_index)
+    if reader_fn is None:
+        raise ValueError(f"Unknown MetricsMessage variant index: {variant_index}")
+
+    return reader_fn(reader)

--- a/setu/telemetry/server.py
+++ b/setu/telemetry/server.py
@@ -1,0 +1,201 @@
+"""Metrics server: ZMQ PULL listener with report aggregation and stall analysis."""
+
+import threading
+import uuid
+from collections import defaultdict
+from dataclasses import dataclass, field
+from typing import Any, Dict, List, Optional
+
+import zmq
+
+from setu.logger import init_logger
+from setu.telemetry.deserialize import (
+    CompilationMetricsRecord,
+    E2EMetricsRecord,
+    NCCLWorkerMetricsRecord,
+    deserialize_metrics_message,
+)
+from setu.telemetry.sinks.base import ReportSink
+
+logger = init_logger(__name__)
+
+
+@dataclass
+class CopySpecReport:
+    """Aggregated report for a single CopySpec execution."""
+
+    copy_op_id: uuid.UUID
+    compile_time_ms: Optional[float] = None
+    e2e_time_ms: Optional[float] = None
+    num_participants: Optional[int] = None
+    participant_instruction_counts: Optional[List] = None
+    pass_timings: Optional[List] = None
+    worker_metrics: List[NCCLWorkerMetricsRecord] = field(default_factory=list)
+    stall_analysis: Optional[Dict[int, Dict[str, Any]]] = None
+
+
+def _compute_stall_analysis(
+    worker_metrics: List[NCCLWorkerMetricsRecord],
+) -> Dict[int, Dict[str, Any]]:
+    """Compute per-group stall analysis from worker metrics.
+
+    For each group index across all workers, compare group elapsed times.
+    The spread (max - min) indicates stall time where faster workers waited
+    at the next barrier for the slowest.
+    """
+    group_completions: Dict[int, list] = defaultdict(list)
+    for wm in worker_metrics:
+        for gt in wm.group_timings:
+            group_completions[gt.group_index].append(
+                {
+                    "node_id": wm.node_id,
+                    "device_rank": wm.device_rank,
+                    "elapsed_ms": gt.elapsed_ms,
+                }
+            )
+
+    stalls: Dict[int, Dict[str, Any]] = {}
+    for group_idx, workers in sorted(group_completions.items()):
+        if not workers:
+            continue
+        max_ms = max(w["elapsed_ms"] for w in workers)
+        min_ms = min(w["elapsed_ms"] for w in workers)
+        stalls[group_idx] = {
+            "max_elapsed_ms": max_ms,
+            "min_elapsed_ms": min_ms,
+            "spread_ms": max_ms - min_ms,
+            "slowest_workers": [w for w in workers if w["elapsed_ms"] == max_ms],
+        }
+    return stalls
+
+
+class MetricsServer:
+    """ZMQ PULL metrics server with report aggregation.
+
+    Receives serialized MetricsMessage from C++ components, deserializes
+    them, aggregates into per-CopySpec reports, and emits completed reports
+    to pluggable sinks.
+
+    Args:
+        endpoint: ZMQ bind endpoint (e.g. "tcp://*:9999").
+        sinks: List of ReportSink instances for output.
+    """
+
+    def __init__(
+        self,
+        endpoint: str = "tcp://*:9999",
+        sinks: Optional[List[ReportSink]] = None,
+    ) -> None:
+        self._endpoint = endpoint
+        self._sinks = sinks or []
+        self._reports: Dict[uuid.UUID, CopySpecReport] = {}
+        self._lock = threading.Lock()
+        self._zmq_context: Optional[zmq.Context] = None
+        self._socket: Optional[zmq.Socket] = None
+        self._thread: Optional[threading.Thread] = None
+        self._running = False
+
+    def start(self) -> None:
+        """Start ZMQ PULL listener in a background thread."""
+        self._zmq_context = zmq.Context()
+        self._socket = self._zmq_context.socket(zmq.PULL)
+        self._socket.bind(self._endpoint)
+        self._socket.setsockopt(zmq.RCVTIMEO, 100)
+        self._running = True
+        self._thread = threading.Thread(
+            target=self._listen_loop, daemon=True, name="MetricsServerThread"
+        )
+        self._thread.start()
+        logger.info("MetricsServer started on %s", self._endpoint)
+
+    def stop(self) -> None:
+        """Stop listener and close sockets."""
+        self._running = False
+        if self._thread is not None:
+            self._thread.join(timeout=2.0)
+            self._thread = None
+        if self._socket is not None:
+            self._socket.close()
+            self._socket = None
+        if self._zmq_context is not None:
+            self._zmq_context.term()
+            self._zmq_context = None
+        for sink in self._sinks:
+            sink.close()
+        logger.info("MetricsServer stopped")
+
+    def get_report(self, copy_op_id: uuid.UUID) -> Optional[CopySpecReport]:
+        """Get aggregated report for a single CopySpec execution."""
+        with self._lock:
+            return self._reports.get(copy_op_id)
+
+    def get_all_reports(self) -> Dict[uuid.UUID, CopySpecReport]:
+        """Get all collected reports."""
+        with self._lock:
+            return dict(self._reports)
+
+    def _listen_loop(self) -> None:
+        """Background thread: receive and process metrics messages."""
+        while self._running:
+            try:
+                data = self._socket.recv()
+            except zmq.Again:
+                continue
+            except zmq.ZMQError:
+                if self._running:
+                    logger.warning("MetricsServer: ZMQ error in recv", exc_info=True)
+                break
+
+            try:
+                record = deserialize_metrics_message(data)
+                self._ingest(record)
+            except Exception:
+                logger.warning(
+                    "MetricsServer: failed to deserialize message", exc_info=True
+                )
+
+    def _ingest(self, record) -> None:
+        """Process a deserialized metrics record."""
+        with self._lock:
+            if isinstance(record, NCCLWorkerMetricsRecord):
+                report = self._get_or_create(record.copy_op_id)
+                report.worker_metrics.append(record)
+
+            elif isinstance(record, CompilationMetricsRecord):
+                report = self._get_or_create(record.copy_op_id)
+                report.compile_time_ms = record.total_compile_time_ms
+                report.num_participants = record.num_participants
+                report.participant_instruction_counts = (
+                    record.participant_instruction_counts
+                )
+                report.pass_timings = [
+                    {"pass_name": pt.pass_name, "elapsed_ms": pt.elapsed_ms}
+                    for pt in record.pass_timings
+                ]
+
+            elif isinstance(record, E2EMetricsRecord):
+                report = self._get_or_create(record.copy_op_id)
+                report.e2e_time_ms = record.e2e_time_ms
+
+                # E2E is the last metric received; finalize the report
+                self._finalize_report(report)
+
+    def _get_or_create(self, copy_op_id: uuid.UUID) -> CopySpecReport:
+        """Get or create a CopySpecReport for the given copy_op_id."""
+        if copy_op_id not in self._reports:
+            self._reports[copy_op_id] = CopySpecReport(copy_op_id=copy_op_id)
+        return self._reports[copy_op_id]
+
+    def _finalize_report(self, report: CopySpecReport) -> None:
+        """Compute stall analysis and emit to sinks."""
+        if report.worker_metrics:
+            report.stall_analysis = _compute_stall_analysis(report.worker_metrics)
+        for sink in self._sinks:
+            try:
+                sink.emit(report)
+            except Exception:
+                logger.warning(
+                    "MetricsServer: sink %s failed to emit",
+                    type(sink).__name__,
+                    exc_info=True,
+                )

--- a/setu/telemetry/sinks/__init__.py
+++ b/setu/telemetry/sinks/__init__.py
@@ -1,0 +1,6 @@
+"""Report sinks for telemetry output."""
+
+from setu.telemetry.sinks.base import ReportSink
+from setu.telemetry.sinks.csv_sink import CSVReportSink
+
+__all__ = ["ReportSink", "CSVReportSink"]

--- a/setu/telemetry/sinks/base.py
+++ b/setu/telemetry/sinks/base.py
@@ -1,0 +1,18 @@
+"""Abstract base class for telemetry report sinks."""
+
+from abc import ABC, abstractmethod
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from setu.telemetry.server import CopySpecReport
+
+
+class ReportSink(ABC):
+    """Pluggable output destination for completed CopySpec reports."""
+
+    @abstractmethod
+    def emit(self, report: "CopySpecReport") -> None:
+        """Write a completed report to the output destination."""
+
+    def close(self) -> None:
+        """Clean up resources (optional)."""

--- a/setu/telemetry/sinks/csv_sink.py
+++ b/setu/telemetry/sinks/csv_sink.py
@@ -1,0 +1,124 @@
+"""CSV report sink: writes telemetry reports as CSV files."""
+
+import csv
+import os
+from typing import TYPE_CHECKING
+
+from setu.logger import init_logger
+from setu.telemetry.sinks.base import ReportSink
+
+if TYPE_CHECKING:
+    from setu.telemetry.server import CopySpecReport
+
+logger = init_logger(__name__)
+
+
+class CSVReportSink(ReportSink):
+    """Writes CopySpec reports as CSV files in an output directory.
+
+    Produces three files (appended to across multiple emit() calls):
+    - summary.csv: one row per CopySpec.
+    - worker_timings.csv: one row per worker per group.
+    - stall_analysis.csv: one row per group.
+    """
+
+    def __init__(self, output_dir: str) -> None:
+        self._output_dir = output_dir
+        os.makedirs(output_dir, exist_ok=True)
+        self._headers_written = {
+            "summary": False,
+            "worker_timings": False,
+            "stall_analysis": False,
+        }
+
+    def emit(self, report: "CopySpecReport") -> None:
+        self._write_summary(report)
+        self._write_worker_timings(report)
+        self._write_stall_analysis(report)
+        logger.debug("CSVReportSink: wrote report for copy_op_id=%s", report.copy_op_id)
+
+    def _write_summary(self, report: "CopySpecReport") -> None:
+        path = os.path.join(self._output_dir, "summary.csv")
+        write_header = not self._headers_written["summary"]
+        with open(path, "a", newline="") as f:
+            writer = csv.writer(f)
+            if write_header:
+                writer.writerow(
+                    [
+                        "copy_op_id",
+                        "compile_time_ms",
+                        "e2e_time_ms",
+                        "num_participants",
+                    ]
+                )
+                self._headers_written["summary"] = True
+            writer.writerow(
+                [
+                    str(report.copy_op_id),
+                    report.compile_time_ms,
+                    report.e2e_time_ms,
+                    report.num_participants,
+                ]
+            )
+
+    def _write_worker_timings(self, report: "CopySpecReport") -> None:
+        path = os.path.join(self._output_dir, "worker_timings.csv")
+        write_header = not self._headers_written["worker_timings"]
+        with open(path, "a", newline="") as f:
+            writer = csv.writer(f)
+            if write_header:
+                writer.writerow(
+                    [
+                        "copy_op_id",
+                        "node_id",
+                        "device_rank",
+                        "group_index",
+                        "elapsed_ms",
+                        "num_ops",
+                    ]
+                )
+                self._headers_written["worker_timings"] = True
+            for wm in report.worker_metrics:
+                for gt in wm.group_timings:
+                    writer.writerow(
+                        [
+                            str(report.copy_op_id),
+                            str(wm.node_id),
+                            wm.device_rank,
+                            gt.group_index,
+                            gt.elapsed_ms,
+                            gt.num_ops,
+                        ]
+                    )
+
+    def _write_stall_analysis(self, report: "CopySpecReport") -> None:
+        if not report.stall_analysis:
+            return
+        path = os.path.join(self._output_dir, "stall_analysis.csv")
+        write_header = not self._headers_written["stall_analysis"]
+        with open(path, "a", newline="") as f:
+            writer = csv.writer(f)
+            if write_header:
+                writer.writerow(
+                    [
+                        "copy_op_id",
+                        "group_index",
+                        "max_elapsed_ms",
+                        "min_elapsed_ms",
+                        "spread_ms",
+                    ]
+                )
+                self._headers_written["stall_analysis"] = True
+            for group_idx, analysis in sorted(report.stall_analysis.items()):
+                writer.writerow(
+                    [
+                        str(report.copy_op_id),
+                        group_idx,
+                        analysis["max_elapsed_ms"],
+                        analysis["min_elapsed_ms"],
+                        analysis["spread_ms"],
+                    ]
+                )
+
+    def close(self) -> None:
+        pass


### PR DESCRIPTION
## Summary
- Add CUDA event timing in NCCLWorker and compilation timing in Planner/PassManager
- New ZMQ-based MetricsSink for streaming metrics from workers and coordinator
- Add Python telemetry module with MetricsServer, deserialization, and CSV sink
- Planner::Compile now returns CompileResult with metrics alongside the plan