### PR TITLE
NodeAgent onboarding: send register sets to coordinator at startup

### DIFF
--- a/csrc/setu/coordinator/Coordinator.cpp
+++ b/csrc/setu/coordinator/Coordinator.cpp
@@ -44,9 +44,9 @@ Coordinator::Coordinator(std::size_t port, PlannerPtr planner,
 
   auto outbox_notify = [this]() { gateway_->NotifyOutbox(); };
 
-  handler_ =
-      std::make_unique<Handler>(inbox_queue_, outbox_queue_, metastore_,
-                                planner_queue_, outbox_notify, handler_sink);
+  handler_ = std::make_unique<Handler>(inbox_queue_, outbox_queue_, metastore_,
+                                       planner_queue_, outbox_notify,
+                                       handler_sink);
   executor_ =
       std::make_unique<Executor>(planner_queue_, outbox_queue_, metastore_,
                                  *planner_, outbox_notify, executor_sink);

--- a/csrc/setu/coordinator/Coordinator.h
+++ b/csrc/setu/coordinator/Coordinator.h
@@ -79,9 +79,9 @@ class Coordinator {
   Queue<InboxMessage> inbox_queue_;
   Queue<OutboxMessage> outbox_queue_;
 
-  /// Queue of PlannerTasks (CopyOperationId + CopySpec) for the Executor to
-  /// compile and dispatch
-  Queue<PlannerTask> planner_queue_;
+  /// Queue of ExecutorTasks for the Executor to process (compile+dispatch or
+  /// onboarding)
+  Queue<ExecutorTask> planner_queue_;
 
   std::unique_ptr<Gateway> gateway_;
   std::unique_ptr<Handler> handler_;

--- a/csrc/setu/coordinator/Executor.cpp
+++ b/csrc/setu/coordinator/Executor.cpp
@@ -23,10 +23,12 @@
 //==============================================================================
 namespace setu::coordinator {
 //==============================================================================
+using setu::commons::enums::ErrorCode;
 using setu::commons::messages::ExecuteRequest;
+using setu::commons::messages::OnboardNodeAgentResponse;
 using setu::planner::Plan;
 //==============================================================================
-Executor::Executor(Queue<PlannerTask>& planner_queue,
+Executor::Executor(Queue<ExecutorTask>& planner_queue,
                    Queue<OutboxMessage>& outbox_queue, MetaStore& metastore,
                    Planner& planner, OutboxNotifyFn outbox_notify,
                    setu::telemetry::MetricsSinkPtr metrics_sink)
@@ -62,52 +64,74 @@ void Executor::Loop() {
   running_ = true;
   while (running_) {
     try {
-      PlannerTask task = planner_queue_.pull();
-      auto t_after_dequeue = std::chrono::steady_clock::now();
+      ExecutorTask task = planner_queue_.pull();
 
-      LOG_DEBUG("Executor received task for copy_op_id: {}", task.copy_op_id);
-
-      auto result = planner_.Compile(task.copy_spec, metastore_, task.hints,
-                                     task.copy_op_id);
-      Plan plan = std::move(result.plan);
-
-      // Submit compilation metrics
-      if (metrics_sink_ && metrics_sink_->IsEnabled()) {
-        metrics_sink_->Submit(
-            setu::telemetry::MetricsMessage{std::move(result.metrics)});
-      }
-
-      LOG_DEBUG("Compiled plan:\n{}", plan);
-
-      // Fragment the plan to into per-node fragments
-      auto fragments = plan.Fragments();
-
-      // Send ExecuteRequest to each node agent
-      for (auto& [node_id, node_plan] : fragments) {
-        Identity node_identity = boost::uuids::to_string(node_id) + "_dealer";
-
-        ExecuteRequest execute_request(task.copy_op_id, std::move(node_plan));
-
-        PushOutbox(OutboxMessage{node_identity, execute_request});
-      }
-
-      // Set expected responses
-      // memory order release so Handler thread can pick it up (using memory
-      // order aqcuire)
-      task.state->expected_responses.store(fragments.size(),
-                                           std::memory_order_release);
-
-      auto t_end = std::chrono::steady_clock::now();
-      auto to_us = [](auto d) {
-        return std::chrono::duration_cast<std::chrono::microseconds>(d).count();
-      };
-      LOG_INFO("Executor: copy_op_id={}, total={}us", task.copy_op_id,
-               to_us(t_end - t_after_dequeue));
-
+      std::visit(
+          [&](auto&& alt) {
+            using T = std::decay_t<decltype(alt)>;
+            if constexpr (std::is_same_v<T, PlannerTask>) {
+              HandlePlannerTask(std::move(alt));
+            } else if constexpr (std::is_same_v<T, OnboardingTask>) {
+              HandleOnboardingTask(std::move(alt));
+            }
+          },
+          std::move(task));
     } catch (const boost::concurrent::sync_queue_is_closed&) {
       return;
     }
   }
+}
+
+void Executor::HandlePlannerTask(PlannerTask task) {
+  auto t_after_dequeue = std::chrono::steady_clock::now();
+
+  LOG_DEBUG("Executor received task for copy_op_id: {}", task.copy_op_id);
+
+  auto result = planner_.Compile(task.copy_spec, metastore_, task.hints,
+                                 task.copy_op_id);
+  Plan plan = std::move(result.plan);
+
+  // Submit compilation metrics
+  if (metrics_sink_ && metrics_sink_->IsEnabled()) {
+    metrics_sink_->Submit(
+        setu::telemetry::MetricsMessage{std::move(result.metrics)});
+  }
+
+  LOG_DEBUG("Compiled plan:\n{}", plan);
+
+  // Fragment the plan to into per-node fragments
+  auto fragments = plan.Fragments();
+
+  // Send ExecuteRequest to each node agent
+  for (auto& [node_id, node_plan] : fragments) {
+    Identity node_identity = boost::uuids::to_string(node_id) + "_dealer";
+
+    ExecuteRequest execute_request(task.copy_op_id, std::move(node_plan));
+
+    PushOutbox(OutboxMessage{node_identity, execute_request});
+  }
+
+  // Set expected responses
+  // memory order release so Handler thread can pick it up (using memory
+  // order aqcuire)
+  task.state->expected_responses.store(fragments.size(),
+                                       std::memory_order_release);
+
+  auto t_end = std::chrono::steady_clock::now();
+  auto to_us = [](auto d) {
+    return std::chrono::duration_cast<std::chrono::microseconds>(d).count();
+  };
+  LOG_INFO("Executor: copy_op_id={}, total={}us", task.copy_op_id,
+           to_us(t_end - t_after_dequeue));
+}
+
+void Executor::HandleOnboardingTask(OnboardingTask task) {
+  LOG_INFO("Executor processing OnboardingTask ({} devices)",
+           task.register_sets.size());
+  planner_.AddBackendRegisterSets(task.register_sets);
+
+  OnboardNodeAgentResponse response(task.request_id, ErrorCode::kSuccess);
+  PushOutbox(OutboxMessage{task.node_agent_identity, response});
 }
 //==============================================================================
 }  // namespace setu::coordinator

--- a/csrc/setu/coordinator/Executor.h
+++ b/csrc/setu/coordinator/Executor.h
@@ -37,7 +37,7 @@ using setu::planner::Planner;
 /// ExecuteRequests through the outbox queue.
 class Executor {
  public:
-  Executor(Queue<PlannerTask>& planner_queue,
+  Executor(Queue<ExecutorTask>& planner_queue,
            Queue<OutboxMessage>& outbox_queue, MetaStore& metastore,
            Planner& planner, OutboxNotifyFn outbox_notify,
            setu::telemetry::MetricsSinkPtr metrics_sink);
@@ -50,7 +50,10 @@ class Executor {
 
   void PushOutbox(OutboxMessage msg);
 
-  Queue<PlannerTask>& planner_queue_;
+  void HandlePlannerTask(PlannerTask task);
+  void HandleOnboardingTask(OnboardingTask task);
+
+  Queue<ExecutorTask>& planner_queue_;
   Queue<OutboxMessage>& outbox_queue_;
   MetaStore& metastore_;
   Planner& planner_;

--- a/csrc/setu/coordinator/Handler.cpp
+++ b/csrc/setu/coordinator/Handler.cpp
@@ -36,7 +36,7 @@ using setu::commons::utils::AggregationParticipant;
 //==============================================================================
 Handler::Handler(Queue<InboxMessage>& inbox_queue,
                  Queue<OutboxMessage>& outbox_queue, MetaStore& metastore,
-                 Queue<PlannerTask>& planner_queue,
+                 Queue<ExecutorTask>& planner_queue,
                  OutboxNotifyFn outbox_notify,
                  setu::telemetry::MetricsSinkPtr metrics_sink)
     : inbox_queue_(inbox_queue),
@@ -88,6 +88,8 @@ void Handler::Loop() {
               HandleGetTensorSpecRequest(inbox_msg.node_agent_identity, msg);
             } else if constexpr (std::is_same_v<T, DeregisterShardsRequest>) {
               HandleDeregisterShardsRequest(inbox_msg.node_agent_identity, msg);
+            } else if constexpr (std::is_same_v<T, OnboardNodeAgentRequest>) {
+              HandleOnboardNodeAgentRequest(inbox_msg.node_agent_identity, msg);
             } else {
               LOG_WARNING("Handler: Unknown message type (index={})",
                           inbox_msg.request.index());
@@ -433,6 +435,19 @@ void Handler::HandleDeregisterShardsRequest(
         "in-flight copy operations",
         tensor_names.size(), node_agent_identity);
   }
+}
+
+void Handler::HandleOnboardNodeAgentRequest(
+    const Identity& node_agent_identity,
+    const OnboardNodeAgentRequest& request) {
+  LOG_INFO("Coordinator received OnboardNodeAgentRequest from {} ({} devices)",
+           node_agent_identity, request.register_sets.size());
+
+  // Route to Executor thread — Planner is only accessed from Executor.
+  // Executor sends the response after processing.
+  planner_queue_.push(
+      OnboardingTask{node_agent_identity, request.request_id,
+                     request.register_sets});
 }
 //==============================================================================
 }  // namespace setu::coordinator

--- a/csrc/setu/coordinator/Handler.h
+++ b/csrc/setu/coordinator/Handler.h
@@ -34,6 +34,7 @@ using setu::commons::NodeId;
 using setu::commons::messages::DeregisterShardsRequest;
 using setu::commons::messages::ExecuteResponse;
 using setu::commons::messages::GetTensorSpecRequest;
+using setu::commons::messages::OnboardNodeAgentRequest;
 using setu::commons::messages::RegisterTensorShardRequest;
 using setu::commons::messages::SubmitCopyRequest;
 using setu::commons::messages::SubmitPullRequest;
@@ -50,7 +51,7 @@ using setu::metastore::MetaStore;
 class Handler {
  public:
   Handler(Queue<InboxMessage>& inbox_queue, Queue<OutboxMessage>& outbox_queue,
-          MetaStore& metastore, Queue<PlannerTask>& planner_queue,
+          MetaStore& metastore, Queue<ExecutorTask>& planner_queue,
           OutboxNotifyFn outbox_notify,
           setu::telemetry::MetricsSinkPtr metrics_sink);
 
@@ -75,6 +76,8 @@ class Handler {
                                   const GetTensorSpecRequest& request);
   void HandleDeregisterShardsRequest(const Identity& node_agent_identity,
                                      const DeregisterShardsRequest& request);
+  void HandleOnboardNodeAgentRequest(const Identity& node_agent_identity,
+                                     const OnboardNodeAgentRequest& request);
 
   /// @brief Unified shard submission logic for both Copy and Pull.
   void HandleShardSubmission(DispatchManager::ShardSubmission submission);
@@ -82,7 +85,7 @@ class Handler {
   Queue<InboxMessage>& inbox_queue_;
   Queue<OutboxMessage>& outbox_queue_;
   MetaStore& metastore_;
-  Queue<PlannerTask>& planner_queue_;
+  Queue<ExecutorTask>& planner_queue_;
   OutboxNotifyFn outbox_notify_;
   setu::telemetry::MetricsSinkPtr metrics_sink_;
 

--- a/csrc/setu/coordinator/Types.h
+++ b/csrc/setu/coordinator/Types.h
@@ -22,6 +22,8 @@
 //==============================================================================
 #include "commons/datatypes/CopySpec.h"
 #include "messaging/Messages.h"
+#include "planner/Participant.h"
+#include "planner/RegisterSet.h"
 #include "planner/hints/HintStore.h"
 //==============================================================================
 namespace setu::coordinator {
@@ -107,6 +109,20 @@ struct PlannerTask {
   CopyOperationStatePtr state;  // Shared with Handler's copy_operations_ map
   HintStore hints;              // Per-operation hints (first-writer-wins)
 };
+//==============================================================================
+// Onboarding task
+//==============================================================================
+
+/// @brief Task to add register sets to the planner backend.
+struct OnboardingTask {
+  Identity node_agent_identity;
+  RequestId request_id;
+  std::unordered_map<setu::planner::Participant, setu::planner::RegisterSet>
+      register_sets;
+};
+
+/// @brief Variant of tasks the Executor can process.
+using ExecutorTask = std::variant<PlannerTask, OnboardingTask>;
 //==============================================================================
 }  // namespace setu::coordinator
 //==============================================================================

--- a/csrc/setu/messaging/Messages.h
+++ b/csrc/setu/messaging/Messages.h
@@ -36,6 +36,8 @@
 #include "messaging/GetTensorSelectionResponse.h"
 #include "messaging/GetTensorSpecRequest.h"
 #include "messaging/GetTensorSpecResponse.h"
+#include "messaging/OnboardNodeAgentRequest.h"
+#include "messaging/OnboardNodeAgentResponse.h"
 #include "messaging/RegisterTensorShardCoordinatorResponse.h"
 #include "messaging/RegisterTensorShardNodeAgentResponse.h"
 #include "messaging/RegisterTensorShardRequest.h"
@@ -60,14 +62,14 @@ using ClientRequest =
 using NodeAgentRequest =
     std::variant<RegisterTensorShardRequest, SubmitCopyRequest,
                  SubmitPullRequest, ExecuteResponse, GetTensorSpecRequest,
-                 DeregisterShardsRequest>;
+                 DeregisterShardsRequest, OnboardNodeAgentRequest>;
 
 /// @brief All messages from Coordinator to NodeAgent
 using CoordinatorMessage =
     std::variant<AllocateTensorRequest, CopyOperationFinishedRequest,
                  ExecuteRequest, RegisterTensorShardCoordinatorResponse,
                  SubmitCopyResponse, WaitForCopyResponse, GetTensorSpecResponse,
-                 DeregisterShardsResponse>;
+                 DeregisterShardsResponse, OnboardNodeAgentResponse>;
 
 using Request =
     std::variant<RegisterTensorShardRequest, SubmitCopyRequest,

--- a/csrc/setu/messaging/OnboardNodeAgentRequest.cpp
+++ b/csrc/setu/messaging/OnboardNodeAgentRequest.cpp
@@ -14,33 +14,28 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //==============================================================================
-#pragma once
+#include "messaging/OnboardNodeAgentRequest.h"
 //==============================================================================
-#include "planner/Plan.h"
-#include "planner/RegisterSet.h"
-#include "planner/ir/cir/Program.h"
+namespace setu::commons::messages {
 //==============================================================================
-namespace setu::planner::targets {
+using setu::commons::utils::BinaryReader;
+using setu::commons::utils::BinaryWriter;
 //==============================================================================
 
-namespace cir = setu::planner::ir::cir;
+void OnboardNodeAgentRequest::Serialize(BinaryBuffer& buffer) const {
+  BinaryWriter writer(buffer);
+  writer.WriteFields(request_id, register_sets);
+}
 
-/// Abstract backend that lowers a CIR Program into a per-device LLC Plan.
-class Backend {
- public:
-  virtual ~Backend() = default;
-  [[nodiscard]] virtual Plan Run(const cir::Program& program /*[in]*/) = 0;
-
-  /// Merge additional per-device register sets into the backend.
-  /// Called during NodeAgent onboarding so the backend learns about all
-  /// devices in the cluster before any compilation occurs.
-  virtual void AddRegisterSets(
-      const std::unordered_map<cir::Device, setu::planner::RegisterSet>&
-          register_sets /*[in]*/) = 0;
-};
-
-using BackendPtr = std::shared_ptr<Backend>;
+OnboardNodeAgentRequest OnboardNodeAgentRequest::Deserialize(
+    const BinaryRange& range) {
+  BinaryReader reader(range);
+  auto [request_id_val, register_sets_val] =
+      reader.ReadFields<RequestId,
+                        std::unordered_map<Participant, RegisterSet>>();
+  return OnboardNodeAgentRequest(request_id_val, std::move(register_sets_val));
+}
 
 //==============================================================================
-}  // namespace setu::planner::targets
+}  // namespace setu::commons::messages
 //==============================================================================

--- a/csrc/setu/messaging/OnboardNodeAgentRequest.h
+++ b/csrc/setu/messaging/OnboardNodeAgentRequest.h
@@ -1,0 +1,61 @@
+//==============================================================================
+// Copyright (c) 2025 Vajra Team; Georgia Institute of Technology; Microsoft
+// Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//==============================================================================
+#pragma once
+//==============================================================================
+#include "commons/StdCommon.h"
+#include "commons/Types.h"
+#include "commons/utils/Serialization.h"
+#include "messaging/BaseRequest.h"
+#include "planner/Participant.h"
+#include "planner/RegisterSet.h"
+//==============================================================================
+namespace setu::commons::messages {
+//==============================================================================
+using setu::commons::utils::BinaryBuffer;
+using setu::commons::utils::BinaryRange;
+using setu::planner::Participant;
+using setu::planner::RegisterSet;
+//==============================================================================
+
+/// Sent by NodeAgent to Coordinator at startup to register its per-device
+/// register sets. The Coordinator merges these into the planner backend so
+/// that CIR → LLC lowering can allocate temporary registers on any device.
+struct OnboardNodeAgentRequest : public BaseRequest {
+  explicit OnboardNodeAgentRequest(
+      std::unordered_map<Participant, RegisterSet> register_sets_param)
+      : BaseRequest(), register_sets(std::move(register_sets_param)) {}
+
+  OnboardNodeAgentRequest(
+      RequestId request_id_param,
+      std::unordered_map<Participant, RegisterSet> register_sets_param)
+      : BaseRequest(request_id_param),
+        register_sets(std::move(register_sets_param)) {}
+
+  [[nodiscard]] std::string ToString() const {
+    return std::format("OnboardNodeAgentRequest(request_id={}, num_devices={})",
+                       request_id, register_sets.size());
+  }
+
+  void Serialize(BinaryBuffer& buffer) const;
+  static OnboardNodeAgentRequest Deserialize(const BinaryRange& range);
+
+  const std::unordered_map<Participant, RegisterSet> register_sets;
+};
+
+//==============================================================================
+}  // namespace setu::commons::messages
+//==============================================================================

--- a/csrc/setu/messaging/OnboardNodeAgentResponse.cpp
+++ b/csrc/setu/messaging/OnboardNodeAgentResponse.cpp
@@ -14,33 +14,27 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //==============================================================================
-#pragma once
+#include "messaging/OnboardNodeAgentResponse.h"
 //==============================================================================
-#include "planner/Plan.h"
-#include "planner/RegisterSet.h"
-#include "planner/ir/cir/Program.h"
+namespace setu::commons::messages {
 //==============================================================================
-namespace setu::planner::targets {
+using setu::commons::utils::BinaryReader;
+using setu::commons::utils::BinaryWriter;
 //==============================================================================
 
-namespace cir = setu::planner::ir::cir;
+void OnboardNodeAgentResponse::Serialize(BinaryBuffer& buffer) const {
+  BinaryWriter writer(buffer);
+  writer.WriteFields(request_id, error_code);
+}
 
-/// Abstract backend that lowers a CIR Program into a per-device LLC Plan.
-class Backend {
- public:
-  virtual ~Backend() = default;
-  [[nodiscard]] virtual Plan Run(const cir::Program& program /*[in]*/) = 0;
-
-  /// Merge additional per-device register sets into the backend.
-  /// Called during NodeAgent onboarding so the backend learns about all
-  /// devices in the cluster before any compilation occurs.
-  virtual void AddRegisterSets(
-      const std::unordered_map<cir::Device, setu::planner::RegisterSet>&
-          register_sets /*[in]*/) = 0;
-};
-
-using BackendPtr = std::shared_ptr<Backend>;
+OnboardNodeAgentResponse OnboardNodeAgentResponse::Deserialize(
+    const BinaryRange& range) {
+  BinaryReader reader(range);
+  auto [request_id_val, error_code_val] =
+      reader.ReadFields<RequestId, ErrorCode>();
+  return OnboardNodeAgentResponse(request_id_val, error_code_val);
+}
 
 //==============================================================================
-}  // namespace setu::planner::targets
+}  // namespace setu::commons::messages
 //==============================================================================

--- a/csrc/setu/messaging/OnboardNodeAgentResponse.h
+++ b/csrc/setu/messaging/OnboardNodeAgentResponse.h
@@ -17,52 +17,34 @@
 #pragma once
 //==============================================================================
 #include "commons/StdCommon.h"
+//==============================================================================
 #include "commons/Types.h"
+#include "commons/utils/Serialization.h"
+#include "messaging/BaseResponse.h"
 //==============================================================================
-#include "commons/datatypes/CopySpec.h"
-#include "metastore/MetaStore.h"
-#include "planner/Plan.h"
-#include "planner/hints/HintStore.h"
-#include "planner/passes/PassManager.h"
-#include "planner/targets/backend.h"
-#include "telemetry/MetricsData.h"
+namespace setu::commons::messages {
 //==============================================================================
-namespace setu::planner {
+using setu::commons::RequestId;
+using setu::commons::utils::BinaryBuffer;
+using setu::commons::utils::BinaryRange;
 //==============================================================================
 
-using setu::commons::CopyOperationId;
-using setu::commons::datatypes::CopySpec;
-using setu::metastore::MetaStore;
-using setu::planner::hints::HintStore;
-using setu::planner::ir::llc::Program;
+/// Acknowledgment from Coordinator to NodeAgent after onboarding.
+struct OnboardNodeAgentResponse : public BaseResponse {
+  explicit OnboardNodeAgentResponse(
+      RequestId request_id_param,
+      ErrorCode error_code_param = ErrorCode::kSuccess)
+      : BaseResponse(request_id_param, error_code_param) {}
 
-/// @brief Result of Planner::Compile, containing the Plan and compilation
-/// metrics.
-struct CompileResult {
-  Plan plan;
-  setu::telemetry::CompilationMetrics metrics;
+  [[nodiscard]] std::string ToString() const {
+    return std::format("OnboardNodeAgentResponse(request_id={}, error_code={})",
+                       request_id, error_code);
+  }
+
+  void Serialize(BinaryBuffer& buffer) const;
+  static OnboardNodeAgentResponse Deserialize(const BinaryRange& range);
 };
 
-class Planner {
- public:
-  Planner(targets::BackendPtr backend, passes::PassManagerPtr pass_manager);
-  [[nodiscard]] CompileResult Compile(const CopySpec& spec,
-                                      MetaStore& metastore,
-                                      const HintStore& hints,
-                                      CopyOperationId copy_op_id);
-
-  /// Forward per-device register sets to the backend.
-  void AddBackendRegisterSets(
-      const std::unordered_map<ir::cir::Device, RegisterSet>&
-          register_sets /*[in]*/);
-
- private:
-  targets::BackendPtr backend_;
-  passes::PassManagerPtr pass_manager_;
-};
-
-using PlannerPtr = std::shared_ptr<Planner>;
-
 //==============================================================================
-}  // namespace setu::planner
+}  // namespace setu::commons::messages
 //==============================================================================

--- a/csrc/setu/node_manager/NodeAgent.cpp
+++ b/csrc/setu/node_manager/NodeAgent.cpp
@@ -20,6 +20,7 @@
 #include "commons/utils/Comm.h"
 #include "commons/utils/TorchTensorIPC.h"
 #include "node_manager/worker/NCCLWorker.h"
+#include "planner/RegisterSet.h"
 #include "telemetry/MetricsSink.h"
 //==============================================================================
 namespace setu::node_manager {
@@ -56,6 +57,8 @@ using setu::commons::messages::GetTensorSelectionResponse;
 using setu::commons::messages::GetTensorSpecRequest;
 using setu::commons::messages::GetTensorSpecResponse;
 using setu::commons::messages::NodeAgentRequest;
+using setu::commons::messages::OnboardNodeAgentRequest;
+using setu::commons::messages::OnboardNodeAgentResponse;
 using setu::commons::messages::RegisterTensorShardCoordinatorResponse;
 using setu::commons::messages::RegisterTensorShardNodeAgentResponse;
 using setu::commons::messages::RegisterTensorShardRequest;
@@ -70,6 +73,7 @@ using setu::commons::utils::Comm;
 using setu::commons::utils::PrepareTensorIPCSpec;
 using setu::commons::utils::ZmqHelper;
 using setu::planner::Plan;
+using setu::planner::RegisterSet;
 using setu::planner::ir::llc::Instruction;
 using setu::planner::ir::llc::Program;
 //==============================================================================
@@ -80,20 +84,23 @@ constexpr std::int32_t kPollTimeoutMs = 100;
 NodeAgent::NodeAgent(NodeId node_id, std::size_t port,
                      std::string coordinator_endpoint,
                      const std::vector<Device>& devices,
-                     std::string lock_base_dir, std::string metrics_endpoint)
+                     std::string lock_base_dir, std::string metrics_endpoint,
+                     std::size_t register_size)
     : node_id_(node_id),
       port_(port),
       coordinator_endpoint_(std::move(coordinator_endpoint)),
       devices_(devices),
       zmq_context_(std::make_shared<zmq::context_t>()),
       lock_base_dir_(std::move(lock_base_dir)),
-      metrics_endpoint_(std::move(metrics_endpoint)) {
+      metrics_endpoint_(std::move(metrics_endpoint)),
+      register_size_(register_size) {
   // Create workers and connect them via inproc sockets on the shared context
   for (const auto& device : devices_) {
     auto device_rank = device.LocalDeviceIndex();
     auto endpoint =
         std::format("inproc://node_{}_worker_{}", node_id_, device_rank);
-    auto worker = std::make_unique<worker::NCCLWorker>(node_id_, device);
+    auto worker = std::make_unique<worker::NCCLWorker>(
+        node_id_, device, RegisterSet::Uniform(1, register_size_));
     worker->Connect(zmq_context_, endpoint);
 
     // Set up telemetry sink for each worker (each gets its own ZMQ socket)
@@ -106,9 +113,19 @@ NodeAgent::NodeAgent(NodeId node_id, std::size_t port,
     workers_.emplace(device_rank, std::move(worker));
   }
 
+  // Build per-Participant register sets for coordinator onboarding
+  std::unordered_map<setu::planner::Participant, RegisterSet>
+      participant_register_sets;
+  for (const auto& device : devices_) {
+    setu::planner::Participant participant(node_id_, device);
+    participant_register_sets.emplace(participant,
+                                      RegisterSet::Uniform(1, register_size_));
+  }
+
   handler_ = std::make_unique<Handler>(node_id_, zmq_context_, port_,
                                        coordinator_endpoint_, executor_queue_,
-                                       shard_id_to_tensor_, lock_base_dir_);
+                                       shard_id_to_tensor_, lock_base_dir_,
+                                       std::move(participant_register_sets));
   // Build register resolver from workers — captures workers_ by reference,
   // safe because NodeAgent outlives the Executor.
   RegisterResolver register_resolver =
@@ -161,14 +178,17 @@ NodeAgent::Handler::Handler(
     NodeId node_id, std::shared_ptr<zmq::context_t> zmq_context,
     std::size_t port, const std::string& coordinator_endpoint,
     Queue<std::pair<CopyOperationId, Plan>>& executor_queue,
-    TensorShardsConcurrentMap& shard_id_to_tensor, std::string lock_base_dir)
+    TensorShardsConcurrentMap& shard_id_to_tensor, std::string lock_base_dir,
+    std::unordered_map<setu::planner::Participant, setu::planner::RegisterSet>
+        register_sets)
     : node_id_(node_id),
       zmq_context_(zmq_context),
       port_(port),
       coordinator_endpoint_(coordinator_endpoint),
       executor_queue_(executor_queue),
       shard_id_to_tensor_(shard_id_to_tensor),
-      lock_base_dir_(std::move(lock_base_dir)) {
+      lock_base_dir_(std::move(lock_base_dir)),
+      register_sets_(std::move(register_sets)) {
   InitSockets();
 }
 
@@ -222,8 +242,29 @@ void NodeAgent::Handler::Stop() {
   }
 }
 
+void NodeAgent::Handler::OnboardWithCoordinator() {
+  LOG_INFO("NodeAgent {} onboarding with coordinator ({} devices)", node_id_,
+           register_sets_.size());
+
+  OnboardNodeAgentRequest request(std::move(register_sets_));
+  Comm::Send<NodeAgentRequest>(sync_socket_, request);
+  auto coordinator_response = Comm::Recv<CoordinatorMessage>(sync_socket_);
+
+  const auto& resp = std::get<OnboardNodeAgentResponse>(coordinator_response);
+  ASSERT_VALID_RUNTIME(
+      resp.error_code == setu::commons::enums::ErrorCode::kSuccess,
+      "OnboardNodeAgent failed with error_code: {}", resp.error_code);
+
+  LOG_INFO("NodeAgent {} onboarding complete", node_id_);
+}
+
 void NodeAgent::Handler::Loop() {
   running_ = true;
+
+  // Onboard with coordinator before entering event loop — sends register
+  // sets so the coordinator knows about this node's devices.
+  OnboardWithCoordinator();
+
   while (running_) {
     auto ready =
         Comm::PollForRead({client_socket_, async_socket_}, kPollTimeoutMs);

--- a/csrc/setu/node_manager/NodeAgent.h
+++ b/csrc/setu/node_manager/NodeAgent.h
@@ -31,6 +31,7 @@
 #include "commons/utils/ZmqHelper.h"
 #include "messaging/Messages.h"
 #include "node_manager/worker/Worker.h"
+#include "planner/Constants.h"
 #include "planner/Planner.h"
 //==============================================================================
 namespace setu::node_manager {
@@ -67,6 +68,8 @@ using setu::commons::messages::GetTensorSelectionRequest;
 using setu::commons::messages::GetTensorSelectionResponse;
 using setu::commons::messages::GetTensorSpecRequest;
 using setu::commons::messages::GetTensorSpecResponse;
+using setu::commons::messages::OnboardNodeAgentRequest;
+using setu::commons::messages::OnboardNodeAgentResponse;
 using setu::commons::messages::RegisterTensorShardCoordinatorResponse;
 using setu::commons::messages::RegisterTensorShardRequest;
 using setu::commons::messages::SubmitCopyRequest;
@@ -92,7 +95,8 @@ class NodeAgent {
   NodeAgent(NodeId node_id, std::size_t port, std::string coordinator_endpoint,
             const std::vector<Device>& devices,
             std::string lock_base_dir = GetDefaultLockBaseDir(),
-            std::string metrics_endpoint = "");
+            std::string metrics_endpoint = "",
+            std::size_t register_size = setu::planner::kRegisterSize);
   ~NodeAgent();
 
   void Start();
@@ -118,7 +122,10 @@ class NodeAgent {
             std::size_t port, const std::string& coordinator_endpoint,
             Queue<std::pair<CopyOperationId, Plan>>& executor_queue,
             TensorShardsConcurrentMap& shard_id_to_tensor,
-            std::string lock_base_dir);
+            std::string lock_base_dir,
+            std::unordered_map<setu::planner::Participant,
+                               setu::planner::RegisterSet>
+                register_sets);
     ~Handler();
 
     void Start();
@@ -198,10 +205,16 @@ class NodeAgent {
     setu::commons::utils::PendingOperations<Identity, ShardId>
         pending_shard_allocs_;
 
+    void OnboardWithCoordinator();
+
     TensorShardMetadataMap tensor_shard_metadata_map_;
     TensorSpecMap tensor_spec_cache_;
     TensorShardsConcurrentMap& shard_id_to_tensor_;
     std::string lock_base_dir_;  ///< Directory for file-based locks (IPC)
+
+    /// Per-device register sets to send to coordinator during onboarding.
+    std::unordered_map<setu::planner::Participant, setu::planner::RegisterSet>
+        register_sets_;
 
     /// Tracks deregistration requests: 1 request (waiter) blocked by 1
     /// coordinator response key (blocker). WaiterId=RequestId,
@@ -266,7 +279,8 @@ class NodeAgent {
   TensorShardsConcurrentMap shard_id_to_tensor_;
   std::string lock_base_dir_;  ///< Directory for file-based locks (IPC)
   std::string
-      metrics_endpoint_;  ///< Telemetry server endpoint (empty = disabled)
+      metrics_endpoint_;       ///< Telemetry server endpoint (empty = disabled)
+  std::size_t register_size_;  ///< Per-register buffer size in bytes
 };
 //==============================================================================
 }  // namespace setu::node_manager

--- a/csrc/setu/planner/Planner.cpp
+++ b/csrc/setu/planner/Planner.cpp
@@ -70,5 +70,10 @@ CompileResult Planner::Compile(const CopySpec& spec, MetaStore& metastore,
   return {std::move(plan), std::move(cm)};
 }
 //==============================================================================
+void Planner::AddBackendRegisterSets(
+    const std::unordered_map<ir::cir::Device, RegisterSet>& register_sets) {
+  backend_->AddRegisterSets(register_sets);
+}
+//==============================================================================
 }  // namespace setu::planner
 //==============================================================================

--- a/csrc/setu/planner/RegisterSet.cpp
+++ b/csrc/setu/planner/RegisterSet.cpp
@@ -14,33 +14,28 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //==============================================================================
-#pragma once
-//==============================================================================
-#include "planner/Plan.h"
 #include "planner/RegisterSet.h"
-#include "planner/ir/cir/Program.h"
 //==============================================================================
-namespace setu::planner::targets {
+#include "commons/utils/Serialization.h"
+//==============================================================================
+namespace setu::planner {
+//==============================================================================
+using setu::commons::utils::BinaryReader;
+using setu::commons::utils::BinaryWriter;
 //==============================================================================
 
-namespace cir = setu::planner::ir::cir;
+void RegisterSet::Serialize(setu::commons::BinaryBuffer& buffer) const {
+  BinaryWriter writer(buffer);
+  writer.Write(sizes_);
+}
 
-/// Abstract backend that lowers a CIR Program into a per-device LLC Plan.
-class Backend {
- public:
-  virtual ~Backend() = default;
-  [[nodiscard]] virtual Plan Run(const cir::Program& program /*[in]*/) = 0;
-
-  /// Merge additional per-device register sets into the backend.
-  /// Called during NodeAgent onboarding so the backend learns about all
-  /// devices in the cluster before any compilation occurs.
-  virtual void AddRegisterSets(
-      const std::unordered_map<cir::Device, setu::planner::RegisterSet>&
-          register_sets /*[in]*/) = 0;
-};
-
-using BackendPtr = std::shared_ptr<Backend>;
+RegisterSet RegisterSet::Deserialize(const setu::commons::BinaryRange& range) {
+  BinaryReader reader(range);
+  RegisterSet set;
+  set.sizes_ = reader.Read<std::vector<std::size_t>>();
+  return set;
+}
 
 //==============================================================================
-}  // namespace setu::planner::targets
+}  // namespace setu::planner
 //==============================================================================

--- a/csrc/setu/planner/RegisterSet.h
+++ b/csrc/setu/planner/RegisterSet.h
@@ -17,6 +17,7 @@
 #pragma once
 //==============================================================================
 #include "commons/StdCommon.h"
+#include "commons/Types.h"
 //==============================================================================
 namespace setu::planner {
 //==============================================================================
@@ -59,6 +60,9 @@ struct RegisterSet {
 
   /// Whether this register set is empty (no registers).
   [[nodiscard]] bool Empty() const { return sizes_.empty(); }
+
+  void Serialize(setu::commons::BinaryBuffer& buffer) const;
+  static RegisterSet Deserialize(const setu::commons::BinaryRange& range);
 
   std::vector<std::size_t> sizes_;  ///< Size in bytes per register index
 };

--- a/csrc/setu/planner/passes/ShortestPathRouting.cpp
+++ b/csrc/setu/planner/passes/ShortestPathRouting.cpp
@@ -15,7 +15,11 @@ cir::Program ShortestPathRouting::Run(cir::Program program,
   // No topology and no routing hints — every copy would resolve to a direct
   // 2-hop path and be cloned unchanged, so skip the rewrite entirely.
   if (!topo_ && hints.GetHints<RoutingHint>().empty()) {
-    return program;
+    auto rw = cir::ProgramRewriter(program);
+    for (std::size_t i = 0; i < program.NumOperations(); ++i) {
+      rw.CloneOp(i);
+    }
+    return rw.Finish();
   }
 
   // Calculate override map from routing hints

--- a/csrc/setu/planner/targets/nccl.cpp
+++ b/csrc/setu/planner/targets/nccl.cpp
@@ -62,6 +62,14 @@ NCCL::NCCL(
     std::unordered_map<cir::Device, setu::planner::RegisterSet> register_sets)
     : register_sets_(std::move(register_sets)) {}
 
+void NCCL::AddRegisterSets(
+    const std::unordered_map<cir::Device, setu::planner::RegisterSet>&
+        register_sets) {
+  for (const auto& [device, reg_set] : register_sets) {
+    register_sets_.insert_or_assign(device, reg_set);
+  }
+}
+
 //==============================================================================
 
 Plan NCCL::Run(const cir::Program& program) {

--- a/csrc/setu/planner/targets/nccl.h
+++ b/csrc/setu/planner/targets/nccl.h
@@ -51,6 +51,10 @@ struct NCCL : public Backend {
 
   [[nodiscard]] Plan Run(const cir::Program& program /*[in]*/) override;
 
+  void AddRegisterSets(
+      const std::unordered_map<cir::Device, setu::planner::RegisterSet>&
+          register_sets /*[in]*/) override;
+
  private:
   std::unordered_map<cir::Device, setu::planner::RegisterSet> register_sets_;
 


### PR DESCRIPTION
## Summary
- NodeAgents send per-device register set info to Coordinator during onboarding
- New OnboardNodeAgentRequest/Response messaging types
- Coordinator forwards register sets to Planner for register-aware planning
- Add RegisterSet::Uniform constructor and serialization support