### PR TITLE
Add read/write shard access tracking to LLC instructions and workers

### DIFF
--- a/csrc/setu/commons/Types.h
+++ b/csrc/setu/commons/Types.h
@@ -65,8 +65,6 @@ using TensorIndices = datatypes::IndexRangeSet;
 using TensorIndicesMap = std::unordered_map<TensorDimName, TensorIndices>;
 /// @brief Unique identifier for a tensor shard (UUID)
 using ShardId = boost::uuids::uuid;
-/// @brief Lookup tensor shard given shard id
-using TensorShardsConcurrentMap = ConcurrentMap<ShardId, torch::Tensor>;
 /// @brief Unique identifier for a copy operation (UUID)
 using CopyOperationId = boost::uuids::uuid;
 /// @brief Unique identifier for a request (UUID)

--- a/csrc/setu/commons/datatypes/TensorShard.h
+++ b/csrc/setu/commons/datatypes/TensorShard.h
@@ -129,6 +129,9 @@ using TensorShardPtr = std::shared_ptr<TensorShard>;
 
 /// @brief Map of shard IDs to TensorShard objects
 using TensorShardsMap = std::unordered_map<ShardId, TensorShardPtr>;
+
+/// @brief Concurrent map for looking up tensor shards by shard ID
+using TensorShardsConcurrentMap = ConcurrentMap<ShardId, TensorShardPtr>;
 //==============================================================================
 }  // namespace setu::commons::datatypes
 //==============================================================================

--- a/csrc/setu/node_manager/NodeAgent.cpp
+++ b/csrc/setu/node_manager/NodeAgent.cpp
@@ -17,10 +17,12 @@
 #include "node_manager/NodeAgent.h"
 //==============================================================================
 #include "commons/Logging.h"
+#include "commons/datatypes/TensorShardHandle.h"
 #include "commons/utils/Comm.h"
 #include "commons/utils/TorchTensorIPC.h"
 #include "node_manager/worker/NCCLWorker.h"
 #include "planner/RegisterSet.h"
+#include "planner/ir/llc/ShardAccess.h"
 #include "telemetry/MetricsSink.h"
 //==============================================================================
 namespace setu::node_manager {
@@ -36,8 +38,13 @@ using setu::commons::datatypes::TensorDimMap;
 using setu::commons::datatypes::TensorSelection;
 using setu::commons::datatypes::TensorShard;
 using setu::commons::datatypes::TensorShardMetadata;
+using setu::commons::datatypes::TensorShardPtr;
+using setu::commons::datatypes::TensorShardReadHandle;
+using setu::commons::datatypes::TensorShardReadHandlePtr;
 using setu::commons::datatypes::TensorShardRef;
 using setu::commons::datatypes::TensorShardSpecPtr;
+using setu::commons::datatypes::TensorShardWriteHandle;
+using setu::commons::datatypes::TensorShardWriteHandlePtr;
 using setu::commons::enums::DeviceKind;
 using setu::commons::enums::ErrorCode;
 using setu::commons::messages::AllocateTensorRequest;
@@ -74,10 +81,62 @@ using setu::commons::utils::PrepareTensorIPCSpec;
 using setu::commons::utils::ZmqHelper;
 using setu::planner::Plan;
 using setu::planner::RegisterSet;
+using setu::planner::ir::llc::GetShardAccess;
 using setu::planner::ir::llc::Instruction;
 using setu::planner::ir::llc::Program;
+using setu::planner::ir::llc::ShardAccessMap;
+using setu::planner::ir::llc::ShardAccessMode;
 //==============================================================================
 constexpr std::int32_t kPollTimeoutMs = 100;
+//==============================================================================
+
+/// @brief Holds all acquired shard lock handles for a plan execution.
+/// Handles are released automatically when this struct goes out of scope.
+struct ProgramLockGuard {
+  std::vector<TensorShardReadHandlePtr> read_handles;
+  std::vector<TensorShardWriteHandlePtr> write_handles;
+};
+
+/// @brief Acquires read/write lock handles for all shards referenced across
+/// all programs in a plan.
+[[nodiscard]] static ProgramLockGuard AcquirePlanLocks(
+    const setu::planner::Plan& plan,
+    const TensorShardsConcurrentMap& shard_map) {
+  // Merge shard access across all programs in the plan
+  ShardAccessMap plan_access_map;
+  for (const auto& [participant, program] : plan.program) {
+    for (const auto& [shard_id, mode] : GetShardAccess(program)) {
+      if (mode == ShardAccessMode::kWrite) {
+        plan_access_map[shard_id] = ShardAccessMode::kWrite;
+      } else {
+        plan_access_map.try_emplace(shard_id, ShardAccessMode::kRead);
+      }
+    }
+  }
+
+  // Acquire locks in sorted order (ShardAccessMap is sorted by ShardId)
+  ProgramLockGuard guard;
+  for (const auto& [shard_id, mode] : plan_access_map) {
+    TensorShardPtr shard_ptr = nullptr;
+    bool found = shard_map.visit(shard_id, [&shard_ptr](const auto& entry) {
+      shard_ptr = entry.second;
+    });
+    ASSERT_VALID_RUNTIME(found, "AcquirePlanLocks: shard {} not found in map",
+                         shard_id);
+
+    if (mode == ShardAccessMode::kWrite) {
+      guard.write_handles.push_back(
+          std::make_shared<TensorShardWriteHandle>(shard_ptr));
+    } else {
+      guard.read_handles.push_back(
+          std::make_shared<TensorShardReadHandle>(shard_ptr));
+    }
+  }
+
+  LOG_DEBUG("Acquired {} read + {} write shard locks for plan",
+            guard.read_handles.size(), guard.write_handles.size());
+  return guard;
+}
 //==============================================================================
 // NodeAgent Implementation
 //==============================================================================
@@ -424,7 +483,7 @@ void NodeAgent::Handler::HandleGetTensorHandleRequest(
 
   bool found_allocated = shard_id_to_tensor_.visit(
       request.shard_id, [&tensor_ipc_spec](const auto& entry) {
-        tensor_ipc_spec.emplace(PrepareTensorIPCSpec(entry.second));
+        tensor_ipc_spec.emplace(PrepareTensorIPCSpec(entry.second->tensor));
       });
 
   if (!found_allocated) {
@@ -598,7 +657,9 @@ void NodeAgent::Handler::AllocateTensor(
       torch::TensorOptions().dtype(spec.dtype).device(spec.device.torch_device);
   torch::Tensor tensor = torch::empty(shape, options);
 
-  shard_id_to_tensor_.insert_or_assign(shard_metadata.id, tensor);
+  auto shard = std::make_shared<TensorShard>(shard_metadata, std::move(tensor),
+                                             lock_base_dir_);
+  shard_id_to_tensor_.insert_or_assign(shard_metadata.id, std::move(shard));
 
   LOG_DEBUG("Successfully allocated shard {} with shape {} on device {}",
             shard_metadata.id, shape, spec.device.torch_device.str());
@@ -741,10 +802,16 @@ void NodeAgent::Executor::Loop() {
     // Block until we receive a (copy_op_id, plan) pair from the queue
     try {
       auto [copy_op_id, plan] = executor_queue_.pull();
+      auto t_dequeued = std::chrono::steady_clock::now();
 
-      // For each worker program in the plan, send it to the corresponding
-      // worker. We send all programs first so workers can execute in parallel,
-      // then collect all responses.
+      for (auto& [participant, program] : plan.program) {
+        EmbellishProgram(program);
+      }
+
+      // Acquire shard locks for all programs in the plan.
+      auto lock_guard = AcquirePlanLocks(plan, shard_id_to_tensor_);
+
+      // Send programs to workers
       std::vector<std::int32_t> sent_device_ranks;
       for (auto& [participant, program] : plan.program) {
         auto device_rank = participant.LocalDeviceIndex();
@@ -753,18 +820,15 @@ void NodeAgent::Executor::Loop() {
                              "No socket found for device_rank: {}",
                              device_rank);
 
-        // Populate device ptrs for instructions
-        EmbellishProgram(program);
-
         LOG_DEBUG("Embellished program: {} {}", participant, program);
-
-        // Send ExecuteProgramRequest to worker
         LOG_DEBUG("Sending program with {} instructions to worker {}",
                   program.size(), device_rank);
         ExecuteProgramRequest request(copy_op_id, program);
         Comm::Send(it->second, request);
         sent_device_ranks.push_back(device_rank);
       }
+
+      auto t_sent = std::chrono::steady_clock::now();
 
       // Wait for acknowledgment from all workers
       for (auto device_rank : sent_device_ranks) {
@@ -773,15 +837,21 @@ void NodeAgent::Executor::Loop() {
             Comm::Recv<ExecuteProgramResponse>(it->second);
       }
 
-      LOG_DEBUG("All workers completed execution for copy_op_id: {}",
-                copy_op_id);
+      auto t_workers_done = std::chrono::steady_clock::now();
 
-      // Notify coordinator that execution is complete (async, fire-and-forget)
+      // Notify coordinator that execution is complete
       ExecuteResponse response(RequestId{}, copy_op_id, ErrorCode::kSuccess);
+
+      auto to_us = [](auto d) {
+        return std::chrono::duration_cast<std::chrono::microseconds>(d).count();
+      };
       LOG_INFO(
-          "NodeAgent Executor: Sending ExecuteResponse to Coordinator for "
-          "copy_op_id={}",
-          copy_op_id);
+          "NodeAgent Executor: copy_op_id={}, embellish+send={}us, "
+          "worker_execution={}us, total={}us, workers={}",
+          copy_op_id, to_us(t_sent - t_dequeued),
+          to_us(t_workers_done - t_sent), to_us(t_workers_done - t_dequeued),
+          sent_device_ranks.size());
+
       Comm::Send<NodeAgentRequest>(async_socket_, response);
     } catch (const boost::concurrent::sync_queue_is_closed&) {
       return;
@@ -795,8 +865,9 @@ void NodeAgent::Executor::EmbellishProgram(Program& program) {
       const auto& shard = ref.AsShard();
       DevicePtr result = nullptr;
       bool found = this->shard_id_to_tensor_.visit(
-          shard.shard_id,
-          [&result](const auto& entry) { result = entry.second.data_ptr(); });
+          shard.shard_id, [&result](const auto& entry) {
+            result = entry.second->GetDevicePtr();
+          });
       ASSERT_VALID_RUNTIME(
           found,
           "Embellish failed: Tensor: {}, Shard: {} not found in "

--- a/csrc/setu/node_manager/NodeAgent.h
+++ b/csrc/setu/node_manager/NodeAgent.h
@@ -22,6 +22,7 @@
 #include "commons/Types.h"
 //==============================================================================
 #include "commons/datatypes/CopySpec.h"
+#include "commons/datatypes/TensorShard.h"
 #include "commons/datatypes/TensorShardMetadata.h"
 #include "commons/datatypes/TensorShardRef.h"
 #include "commons/datatypes/TensorShardSpec.h"
@@ -45,13 +46,13 @@ using setu::commons::Queue;
 using setu::commons::RequestId;
 using setu::commons::ShardId;
 using setu::commons::TensorName;
-using setu::commons::TensorShardsConcurrentMap;
 using setu::commons::datatypes::CopySpec;
 using setu::commons::datatypes::Device;
 using setu::commons::datatypes::TensorShardMetadata;
 using setu::commons::datatypes::TensorShardMetadataMap;
 using setu::commons::datatypes::TensorShardMetadataPtr;
 using setu::commons::datatypes::TensorShardRef;
+using setu::commons::datatypes::TensorShardsConcurrentMap;
 using setu::commons::datatypes::TensorShardSpec;
 using setu::commons::datatypes::TensorSpec;
 using setu::commons::datatypes::TensorSpecMap;

--- a/csrc/setu/planner/ir/llc/Instruction.cpp
+++ b/csrc/setu/planner/ir/llc/Instruction.cpp
@@ -85,6 +85,11 @@ void Instruction::Embellish(
       instr);
 }
 
+ShardAccessMap Instruction::GetShardAccess() const {
+  return std::visit([](const auto& inst) { return inst.GetShardAccess(); },
+                    instr);
+}
+
 //==============================================================================
 }  // namespace setu::planner::ir::llc
 //==============================================================================

--- a/csrc/setu/planner/ir/llc/Instruction.h
+++ b/csrc/setu/planner/ir/llc/Instruction.h
@@ -86,6 +86,10 @@ struct Instruction {
 
   void Embellish(const std::function<DevicePtr(const BufferRef&)>& resolver);
 
+  /// @brief Extract shard access requirements for this instruction.
+  /// @return Map of shard IDs to access modes (empty for InitComm/UseComm)
+  [[nodiscard]] ShardAccessMap GetShardAccess() const;
+
   InstructionVariant instr;
 };
 

--- a/csrc/setu/planner/ir/llc/ShardAccess.cpp
+++ b/csrc/setu/planner/ir/llc/ShardAccess.cpp
@@ -14,20 +14,28 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //==============================================================================
-#include "planner/ir/llc/instructions/Barrier.h"
+#include "planner/ir/llc/ShardAccess.h"
 //==============================================================================
 namespace setu::planner::ir::llc {
 //==============================================================================
 
-std::string Barrier::ToString() const { return "Barrier()"; }
+ShardAccessMap GetShardAccess(const Program& program) {
+  ShardAccessMap access_map;
 
-void Barrier::Serialize(BinaryBuffer& /*buffer*/) const {
-  // No fields to serialize — the type tag is written by Instruction::Serialize
+  for (const auto& instruction : program) {
+    for (const auto& [shard_id, mode] : instruction.GetShardAccess()) {
+      if (mode == ShardAccessMode::kWrite) {
+        // Write always wins (override any existing read)
+        access_map[shard_id] = ShardAccessMode::kWrite;
+      } else {
+        // Read: only insert if not already present (don't downgrade write)
+        access_map.try_emplace(shard_id, ShardAccessMode::kRead);
+      }
+    }
+  }
+
+  return access_map;
 }
-
-Barrier Barrier::Deserialize(const BinaryRange& /*range*/) { return Barrier(); }
-
-ShardAccessMap Barrier::GetShardAccess() const { return {}; }
 
 //==============================================================================
 }  // namespace setu::planner::ir::llc

--- a/csrc/setu/planner/ir/llc/ShardAccess.h
+++ b/csrc/setu/planner/ir/llc/ShardAccess.h
@@ -14,20 +14,25 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //==============================================================================
-#include "planner/ir/llc/instructions/Barrier.h"
+#pragma once
+//==============================================================================
+#include "planner/ir/llc/Instruction.h"
 //==============================================================================
 namespace setu::planner::ir::llc {
 //==============================================================================
 
-std::string Barrier::ToString() const { return "Barrier()"; }
-
-void Barrier::Serialize(BinaryBuffer& /*buffer*/) const {
-  // No fields to serialize — the type tag is written by Instruction::Serialize
-}
-
-Barrier Barrier::Deserialize(const BinaryRange& /*range*/) { return Barrier(); }
-
-ShardAccessMap Barrier::GetShardAccess() const { return {}; }
+/**
+ * @brief Extract merged, sorted shard access requirements for an entire
+ * program.
+ *
+ * Scans all instructions via Instruction::GetShardAccess(), merges access
+ * modes per shard (write takes precedence over read for the same shard),
+ * and returns results sorted by ShardId for consistent lock ordering.
+ *
+ * @param program The IR program to analyze
+ * @return Sorted map of shard IDs to access modes, deduplicated
+ */
+[[nodiscard]] ShardAccessMap GetShardAccess(const Program& program);
 
 //==============================================================================
 }  // namespace setu::planner::ir::llc

--- a/csrc/setu/planner/ir/llc/ShardAccessTypes.h
+++ b/csrc/setu/planner/ir/llc/ShardAccessTypes.h
@@ -16,45 +16,24 @@
 //==============================================================================
 #pragma once
 //==============================================================================
-#include <nccl.h>
-//==============================================================================
-#include "planner/ir/llc/ShardAccessTypes.h"
-#include "setu/commons/StdCommon.h"
-#include "setu/commons/Types.h"
-#include "setu/commons/utils/Serialization.h"
+#include "commons/StdCommon.h"
+#include "commons/Types.h"
 //==============================================================================
 namespace setu::planner::ir::llc {
 //==============================================================================
-using setu::commons::utils::BinaryBuffer;
-using setu::commons::utils::BinaryRange;
-using setu::commons::utils::BinaryReader;
-using setu::commons::utils::BinaryWriter;
+using setu::commons::ShardId;
 //==============================================================================
 
-/// Switch to an already-initialized NCCL communicator.
-///
-/// Subsequent Send/Receive instructions use this communicator until the
-/// next UseComm or InitComm instruction.
-struct UseComm {
-  explicit UseComm(ncclUniqueId comm_id) : comm_id(std::move(comm_id)) {}
-
-  ~UseComm() = default;
-  UseComm(const UseComm&) = default;
-  UseComm& operator=(const UseComm&) = default;
-  UseComm(UseComm&&) = default;
-  UseComm& operator=(UseComm&&) = default;
-
-  [[nodiscard]] std::string ToString() const;
-
-  void Serialize(BinaryBuffer& buffer) const;
-
-  static UseComm Deserialize(const BinaryRange& range);
-
-  /// @brief Extract shard access requirements for this instruction.
-  [[nodiscard]] ShardAccessMap GetShardAccess() const;
-
-  ncclUniqueId comm_id;
+/// @brief Access mode for a tensor shard within a program
+enum class ShardAccessMode : std::uint8_t {
+  kRead,   ///< Shared read access (source of Copy/Send)
+  kWrite,  ///< Exclusive write access (destination of Copy/Receive)
 };
+
+/// @brief Sorted map from shard ID to its access mode.
+/// Sorted by ShardId (UUID) for consistent lock ordering.
+/// Each shard appears at most once; write takes precedence over read.
+using ShardAccessMap = std::map<ShardId, ShardAccessMode>;
 
 //==============================================================================
 }  // namespace setu::planner::ir::llc

--- a/csrc/setu/planner/ir/llc/instructions/Barrier.h
+++ b/csrc/setu/planner/ir/llc/instructions/Barrier.h
@@ -19,6 +19,8 @@
 #include "setu/commons/StdCommon.h"
 #include "setu/commons/utils/Serialization.h"
 //==============================================================================
+#include "planner/ir/llc/ShardAccessTypes.h"
+//==============================================================================
 namespace setu::planner::ir::llc {
 //==============================================================================
 using setu::commons::utils::BinaryBuffer;
@@ -45,6 +47,9 @@ struct Barrier {
   void Serialize(BinaryBuffer& buffer) const;
 
   static Barrier Deserialize(const BinaryRange& range);
+
+  /// @brief Extract shard access requirements for this instruction.
+  [[nodiscard]] ShardAccessMap GetShardAccess() const;
 };
 
 //==============================================================================

--- a/csrc/setu/planner/ir/llc/instructions/Copy.cpp
+++ b/csrc/setu/planner/ir/llc/instructions/Copy.cpp
@@ -57,6 +57,18 @@ void Copy::Embellish(
   dst_ptr = resolver(dst_ref);
 }
 
+ShardAccessMap Copy::GetShardAccess() const {
+  ShardAccessMap access_map;
+  // Write on dst always wins; read on src only if not already written
+  if (dst_ref.IsShard()) {
+    access_map[dst_ref.AsShard().shard_id] = ShardAccessMode::kWrite;
+  }
+  if (src_ref.IsShard()) {
+    access_map.try_emplace(src_ref.AsShard().shard_id, ShardAccessMode::kRead);
+  }
+  return access_map;
+}
+
 //==============================================================================
 }  // namespace setu::planner::ir::llc
 //==============================================================================

--- a/csrc/setu/planner/ir/llc/instructions/Copy.h
+++ b/csrc/setu/planner/ir/llc/instructions/Copy.h
@@ -21,6 +21,7 @@
 #include "commons/enums/Enums.h"
 #include "commons/utils/Serialization.h"
 //==============================================================================
+#include "planner/ir/llc/ShardAccessTypes.h"
 #include "planner/ir/ref/BufferRef.h"
 #include "planner/ir/ref/ShardRef.h"
 //==============================================================================
@@ -71,6 +72,9 @@ struct Copy {
    * @brief Populates the device pointers by looking up the base address.
    */
   void Embellish(const std::function<DevicePtr(const BufferRef&)>& resolver);
+
+  /// @brief Extract shard access requirements for this instruction.
+  [[nodiscard]] ShardAccessMap GetShardAccess() const;
 
   BufferRef src_ref;
   std::size_t src_offset_bytes;

--- a/csrc/setu/planner/ir/llc/instructions/InitComm.cpp
+++ b/csrc/setu/planner/ir/llc/instructions/InitComm.cpp
@@ -52,6 +52,8 @@ InitComm InitComm::Deserialize(const BinaryRange& range) {
   return InitComm(comm_id, participant_to_rank);
 }
 
+ShardAccessMap InitComm::GetShardAccess() const { return {}; }
+
 //==============================================================================
 }  // namespace setu::planner::ir::llc
 //==============================================================================

--- a/csrc/setu/planner/ir/llc/instructions/InitComm.h
+++ b/csrc/setu/planner/ir/llc/instructions/InitComm.h
@@ -18,6 +18,7 @@
 //==============================================================================
 #include <nccl.h>
 //==============================================================================
+#include "planner/ir/llc/ShardAccessTypes.h"
 #include "setu/commons/StdCommon.h"
 #include "setu/commons/Types.h"
 #include "setu/commons/datatypes/Device.h"
@@ -57,6 +58,9 @@ struct InitComm {
   void Serialize(BinaryBuffer& buffer) const;
 
   static InitComm Deserialize(const BinaryRange& range);
+
+  /// @brief Extract shard access requirements for this instruction.
+  [[nodiscard]] ShardAccessMap GetShardAccess() const;
 
   ncclUniqueId comm_id;
   std::unordered_map<Participant, DeviceRank> participant_to_rank;

--- a/csrc/setu/planner/ir/llc/instructions/Receive.cpp
+++ b/csrc/setu/planner/ir/llc/instructions/Receive.cpp
@@ -51,6 +51,14 @@ void Receive::Embellish(
   dst_ptr = resolver(dst_ref);
 }
 
+ShardAccessMap Receive::GetShardAccess() const {
+  ShardAccessMap access_map;
+  if (dst_ref.IsShard()) {
+    access_map[dst_ref.AsShard().shard_id] = ShardAccessMode::kWrite;
+  }
+  return access_map;
+}
+
 //==============================================================================
 }  // namespace setu::planner::ir::llc
 //==============================================================================

--- a/csrc/setu/planner/ir/llc/instructions/Receive.h
+++ b/csrc/setu/planner/ir/llc/instructions/Receive.h
@@ -21,6 +21,7 @@
 #include "commons/enums/Enums.h"
 #include "commons/utils/Serialization.h"
 //==============================================================================
+#include "planner/ir/llc/ShardAccessTypes.h"
 #include "planner/ir/ref/BufferRef.h"
 #include "planner/ir/ref/ShardRef.h"
 //==============================================================================
@@ -69,6 +70,9 @@ struct Receive {
    * @brief Populates the device pointers by looking up the base address.
    */
   void Embellish(const std::function<DevicePtr(const BufferRef&)>& resolver);
+
+  /// @brief Extract shard access requirements for this instruction.
+  [[nodiscard]] ShardAccessMap GetShardAccess() const;
 
   BufferRef dst_ref;
   std::size_t offset_bytes;

--- a/csrc/setu/planner/ir/llc/instructions/Send.cpp
+++ b/csrc/setu/planner/ir/llc/instructions/Send.cpp
@@ -51,6 +51,14 @@ void Send::Embellish(
   src_ptr = resolver(src_ref);
 }
 
+ShardAccessMap Send::GetShardAccess() const {
+  ShardAccessMap access_map;
+  if (src_ref.IsShard()) {
+    access_map.try_emplace(src_ref.AsShard().shard_id, ShardAccessMode::kRead);
+  }
+  return access_map;
+}
+
 //==============================================================================
 }  // namespace setu::planner::ir::llc
 //==============================================================================

--- a/csrc/setu/planner/ir/llc/instructions/Send.h
+++ b/csrc/setu/planner/ir/llc/instructions/Send.h
@@ -21,6 +21,7 @@
 #include "commons/enums/Enums.h"
 #include "commons/utils/Serialization.h"
 //==============================================================================
+#include "planner/ir/llc/ShardAccessTypes.h"
 #include "planner/ir/ref/BufferRef.h"
 #include "planner/ir/ref/ShardRef.h"
 //==============================================================================
@@ -68,6 +69,9 @@ struct Send {
    * @brief Populates the device pointers by looking up the base address.
    */
   void Embellish(const std::function<DevicePtr(const BufferRef&)>& resolver);
+
+  /// @brief Extract shard access requirements for this instruction.
+  [[nodiscard]] ShardAccessMap GetShardAccess() const;
 
   BufferRef src_ref;
   std::size_t offset_bytes;

--- a/csrc/setu/planner/ir/llc/instructions/UseComm.cpp
+++ b/csrc/setu/planner/ir/llc/instructions/UseComm.cpp
@@ -39,6 +39,8 @@ UseComm UseComm::Deserialize(const BinaryRange& range) {
   return UseComm(comm_id);
 }
 
+ShardAccessMap UseComm::GetShardAccess() const { return {}; }
+
 //==============================================================================
 }  // namespace setu::planner::ir::llc
 //==============================================================================

--- a/test/test_worker_locks.py
+++ b/test/test_worker_locks.py
@@ -1,0 +1,720 @@
+"""
+Integration tests for tensor shard read/write locks during worker execution.
+
+Tests that the executor correctly acquires and releases file-based read/write
+locks when executing programs. Verifies:
+- Copy operations complete correctly with locking (end-to-end)
+- A client write lock on a destination shard delays copy execution
+- A client read lock on a source shard coexists with executor read locks
+- Locks are released after execution, allowing client access
+"""
+
+import time
+import uuid
+
+import pytest
+import torch
+import torch.multiprocessing as mp
+from torch.multiprocessing.reductions import rebuild_cuda_tensor
+
+
+def _run_coordinator(port: int, ready_event, stop_event):
+    """Run the Coordinator in a separate process."""
+    from setu._coordinator import Coordinator
+
+    coordinator = Coordinator(port)
+    coordinator.start()
+    ready_event.set()
+
+    while not stop_event.is_set():
+        time.sleep(0.05)
+
+    coordinator.stop()
+
+
+def _run_node_agent(
+    port: int,
+    coordinator_endpoint: str,
+    ready_event,
+    stop_event,
+    node_id=None,
+    device_index: int = 0,
+):
+    """Run the NodeAgent in a separate process."""
+    from setu._commons.datatypes import Device
+    from setu._node_manager import NodeAgent
+
+    if node_id is None:
+        node_id = uuid.uuid4()
+
+    devices = [Device(torch_device=torch.device(f"cuda:{device_index}"))]
+
+    node_agent = NodeAgent(
+        node_id=node_id,
+        port=port,
+        coordinator_endpoint=coordinator_endpoint,
+        devices=devices,
+    )
+    node_agent.start()
+    ready_event.set()
+
+    while not stop_event.is_set():
+        time.sleep(0.05)
+
+    node_agent.stop()
+
+
+def _rebuild_tensor_from_handle(tensor_ipc_spec):
+    """Rebuild a CUDA tensor from an IPC spec."""
+    spec_dict = tensor_ipc_spec.to_dict()
+    return rebuild_cuda_tensor(
+        **spec_dict,
+        tensor_cls=torch.Tensor,
+        storage_cls=torch.storage.UntypedStorage,
+    )
+
+
+@pytest.fixture(scope="module")
+def infrastructure():
+    """Start Coordinator and NodeAgent once for all tests in this module."""
+    if not torch.cuda.is_available():
+        pytest.skip("CUDA not available")
+
+    coordinator_port = 29700
+    node_agent_port = 29800
+    coordinator_endpoint = f"tcp://localhost:{coordinator_port}"
+    client_endpoint = f"tcp://localhost:{node_agent_port}"
+
+    ctx = mp.get_context("spawn")
+    coordinator_ready = ctx.Event()
+    node_agent_ready = ctx.Event()
+    stop_event = ctx.Event()
+
+    coordinator_proc = ctx.Process(
+        target=_run_coordinator,
+        args=(coordinator_port, coordinator_ready, stop_event),
+    )
+    coordinator_proc.start()
+    assert coordinator_ready.wait(timeout=10), "Coordinator failed to start"
+
+    node_agent_proc = ctx.Process(
+        target=_run_node_agent,
+        args=(
+            node_agent_port,
+            coordinator_endpoint,
+            node_agent_ready,
+            stop_event,
+        ),
+    )
+    node_agent_proc.start()
+    assert node_agent_ready.wait(timeout=10), "NodeAgent failed to start"
+
+    time.sleep(0.1)
+
+    yield {"client_endpoint": client_endpoint}
+
+    stop_event.set()
+    time.sleep(0.1)
+    for proc in [node_agent_proc, coordinator_proc]:
+        proc.join(timeout=3)
+        if proc.is_alive():
+            proc.terminate()
+            proc.join(timeout=1)
+
+
+# ==============================================================================
+# Helper: register + write + pull in subprocess
+# ==============================================================================
+
+
+def _source_register_and_write(
+    client_endpoint: str,
+    tensor_name: str,
+    dims_data: list,
+    fill_value: float,
+    ready_event,
+    result_queue,
+    device_index: int = 0,
+):
+    """Register source shard, write data, then stay alive."""
+    from setu._client import Client
+    from setu._commons.datatypes import Device, TensorDimSpec, TensorShardSpec
+
+    try:
+        client = Client()
+        client.connect(client_endpoint)
+
+        dims_spec = [
+            TensorDimSpec(name, size, start, end)
+            for name, size, start, end in dims_data
+        ]
+        device = Device(torch_device=torch.device(f"cuda:{device_index}"))
+        shard_spec = TensorShardSpec(
+            name=tensor_name, dims=dims_spec, dtype=torch.float32, device=device
+        )
+
+        shard_ref = client.register_tensor_shard(shard_spec)
+        if shard_ref is None:
+            raise RuntimeError(f"Failed to register source shard {tensor_name}")
+
+        client.wait_for_shard_allocation(shard_ref.shard_id)
+
+        tensor_ipc_spec, _, _ = client.get_tensor_handle(shard_ref)
+        tensor = _rebuild_tensor_from_handle(tensor_ipc_spec)
+        tensor.fill_(fill_value)
+        torch.cuda.synchronize()
+
+        result_queue.put({"success": True, "shard_id": shard_ref.shard_id})
+        ready_event.set()
+
+        # Stay alive
+        while True:
+            time.sleep(0.1)
+
+    except Exception as e:
+        import traceback
+
+        result_queue.put(
+            {"success": False, "error": str(e), "tb": traceback.format_exc()}
+        )
+        ready_event.set()
+
+
+def _dest_pull_and_verify(
+    client_endpoint: str,
+    src_tensor_name: str,
+    dst_tensor_name: str,
+    dims_data: list,
+    expected_value: float,
+    source_ready_event,
+    result_queue,
+    device_index: int = 0,
+):
+    """Wait for source, register dest shard, pull data, verify value."""
+    from setu._client import Client
+    from setu._commons.datatypes import (
+        CopySpec,
+        Device,
+        TensorDim,
+        TensorDimSpec,
+        TensorSelection,
+        TensorShardSpec,
+    )
+
+    try:
+        if not source_ready_event.wait(timeout=30):
+            raise RuntimeError("Timeout waiting for source")
+
+        client = Client()
+        client.connect(client_endpoint)
+
+        dims_spec = [
+            TensorDimSpec(name, size, start, end)
+            for name, size, start, end in dims_data
+        ]
+        device = Device(torch_device=torch.device(f"cuda:{device_index}"))
+        shard_spec = TensorShardSpec(
+            name=dst_tensor_name, dims=dims_spec, dtype=torch.float32, device=device
+        )
+
+        shard_ref = client.register_tensor_shard(shard_spec)
+        if shard_ref is None:
+            raise RuntimeError(f"Failed to register dest shard {dst_tensor_name}")
+        client.wait_for_shard_allocation(shard_ref.shard_id)
+
+        # Build CopySpec for pull
+        dim_map = {name: TensorDim(name, size) for name, size, _, _ in dims_data}
+        src_sel = TensorSelection(src_tensor_name, dim_map)
+        dst_sel = TensorSelection(dst_tensor_name, dim_map)
+        copy_spec = CopySpec(src_tensor_name, dst_tensor_name, src_sel, dst_sel)
+
+        copy_op_id = client.submit_pull(copy_spec)
+        if copy_op_id is None:
+            raise RuntimeError("Failed to submit pull")
+
+        client.wait_for_copy(copy_op_id)
+
+        # Verify
+        tensor_ipc_spec, _, _ = client.get_tensor_handle(shard_ref)
+        tensor = _rebuild_tensor_from_handle(tensor_ipc_spec)
+        torch.cuda.synchronize()
+        actual = tensor.mean().item()
+        matches = abs(actual - expected_value) < 1e-5
+
+        result_queue.put({"success": True, "matches": matches, "actual": actual})
+        client.disconnect()
+
+    except Exception as e:
+        import traceback
+
+        result_queue.put(
+            {"success": False, "error": str(e), "tb": traceback.format_exc()}
+        )
+
+
+# ==============================================================================
+# Tests
+# ==============================================================================
+
+
+@pytest.mark.gpu
+def test_pull_correctness_with_locks(infrastructure):
+    """
+    End-to-end test: pull operation transfers data correctly with shard locking.
+
+    The executor acquires read lock on source, write lock on destination,
+    dispatches to the worker, and releases both after completion.
+    """
+    client_endpoint = infrastructure["client_endpoint"]
+    dims_data = [("dim_0", 8, 0, 8), ("dim_1", 16, 0, 16)]
+    fill_value = 42.0
+
+    ctx = mp.get_context("spawn")
+    source_ready = ctx.Event()
+    src_queue = ctx.Queue()
+    dst_queue = ctx.Queue()
+
+    src_proc = ctx.Process(
+        target=_source_register_and_write,
+        args=(
+            client_endpoint,
+            "lock_src_1",
+            dims_data,
+            fill_value,
+            source_ready,
+            src_queue,
+        ),
+    )
+    src_proc.start()
+
+    dst_proc = ctx.Process(
+        target=_dest_pull_and_verify,
+        args=(
+            client_endpoint,
+            "lock_src_1",
+            "lock_dst_1",
+            dims_data,
+            fill_value,
+            source_ready,
+            dst_queue,
+        ),
+    )
+    dst_proc.start()
+
+    dst_proc.join(timeout=30)
+    src_proc.terminate()
+    src_proc.join(timeout=3)
+
+    src_result = src_queue.get()
+    assert src_result["success"], f"Source failed: {src_result.get('error')}"
+
+    dst_result = dst_queue.get()
+    assert dst_result["success"], f"Dest failed: {dst_result.get('error')}"
+    assert dst_result[
+        "matches"
+    ], f"Pull data mismatch: expected {fill_value}, got {dst_result['actual']}"
+
+
+@pytest.mark.gpu
+def test_read_lock_released_after_pull(infrastructure):
+    """
+    After a pull completes, the executor releases locks and a client
+    can freely write to the destination tensor.
+    """
+    from setu._commons.datatypes import Device, TensorDimSpec, TensorShardSpec
+    from setu.client import Client
+
+    client_endpoint = infrastructure["client_endpoint"]
+    dims_data = [("dim_0", 4, 0, 4), ("dim_1", 8, 0, 8)]
+    fill_value = 10.0
+
+    ctx = mp.get_context("spawn")
+    source_ready = ctx.Event()
+    src_queue = ctx.Queue()
+    dst_queue = ctx.Queue()
+
+    # Source registers and writes fill_value
+    src_proc = ctx.Process(
+        target=_source_register_and_write,
+        args=(
+            client_endpoint,
+            "lock_release_src",
+            dims_data,
+            fill_value,
+            source_ready,
+            src_queue,
+        ),
+    )
+    src_proc.start()
+
+    # Dest registers and pulls
+    dst_proc = ctx.Process(
+        target=_dest_pull_and_verify,
+        args=(
+            client_endpoint,
+            "lock_release_src",
+            "lock_release_dst",
+            dims_data,
+            fill_value,
+            source_ready,
+            dst_queue,
+        ),
+    )
+    dst_proc.start()
+
+    dst_proc.join(timeout=30)
+    src_proc.terminate()
+    src_proc.join(timeout=3)
+
+    dst_result = dst_queue.get()
+    assert dst_result["success"], f"Pull failed: {dst_result.get('error')}"
+    assert dst_result["matches"], "Pull data should match"
+
+    # After pull completes, locks are released.
+    # A new client should be able to write to the destination tensor.
+    client = Client(client_endpoint)
+
+    device = Device(torch_device=torch.device("cuda:0"))
+    dims = [
+        TensorDimSpec(name, size, start, end) for name, size, start, end in dims_data
+    ]
+    shard_spec = TensorShardSpec(
+        name="lock_release_dst", dims=dims, dtype=torch.float32, device=device
+    )
+    shard_ref = client.register_tensor_shard(shard_spec)
+
+    # If the executor still held locks, this would deadlock
+    if shard_ref is not None:
+        with client.write(shard_ref) as tensor:
+            tensor.fill_(99.0)
+
+        with client.read(shard_ref) as tensor:
+            assert torch.allclose(
+                tensor, torch.full_like(tensor, 99.0)
+            ), "Client should be able to write after executor releases locks"
+
+    client.disconnect()
+
+
+def _register_lock_pull_release(
+    client_endpoint: str,
+    src_tensor_name: str,
+    dst_tensor_name: str,
+    dims_data: list,
+    hold_seconds: float,
+    source_ready_event,
+    lock_acquired_event,
+    result_queue,
+    device_index: int = 0,
+):
+    """Register dest shard, acquire write lock, submit pull, hold lock, release, wait.
+
+    The pull is submitted while the write lock is held. Since submit_pull is
+    non-blocking (it just sends a request), the executor will start trying to
+    acquire the write lock and block. After hold_seconds we release the lock,
+    letting the executor complete.
+    """
+    from setu._client import Client
+    from setu._commons.datatypes import (
+        CopySpec,
+        Device,
+        TensorDim,
+        TensorDimSpec,
+        TensorSelection,
+        TensorShard,
+        TensorShardSpec,
+    )
+    from setu._commons.datatypes import TensorShardWriteHandle as NativeWriteHandle
+
+    try:
+        if not source_ready_event.wait(timeout=30):
+            raise RuntimeError("Timeout waiting for source")
+
+        client = Client()
+        client.connect(client_endpoint)
+
+        device = Device(torch_device=torch.device(f"cuda:{device_index}"))
+        dims = [
+            TensorDimSpec(name, size, start, end)
+            for name, size, start, end in dims_data
+        ]
+        shard_spec = TensorShardSpec(
+            name=dst_tensor_name, dims=dims, dtype=torch.float32, device=device
+        )
+        shard_ref = client.register_tensor_shard(shard_spec)
+        if shard_ref is None:
+            raise RuntimeError(f"Failed to register shard {dst_tensor_name}")
+
+        client.wait_for_shard_allocation(shard_ref.shard_id)
+
+        # Build TensorShard for file lock
+        tensor_ipc_spec, metadata, lock_base_dir = client.get_tensor_handle(shard_ref)
+        tensor = _rebuild_tensor_from_handle(tensor_ipc_spec)
+        shard = TensorShard(
+            metadata=metadata, tensor=tensor, lock_base_dir=lock_base_dir
+        )
+
+        # Acquire exclusive write lock
+        write_handle = NativeWriteHandle(shard)
+        lock_acquired_event.set()
+
+        # Submit pull while holding the lock (non-blocking — just sends request)
+        dim_map = {name: TensorDim(name, size) for name, size, _, _ in dims_data}
+        src_sel = TensorSelection(src_tensor_name, dim_map)
+        dst_sel = TensorSelection(dst_tensor_name, dim_map)
+        copy_spec = CopySpec(src_tensor_name, dst_tensor_name, src_sel, dst_sel)
+
+        start_time = time.time()
+        copy_op_id = client.submit_pull(copy_spec)
+        if copy_op_id is None:
+            raise RuntimeError("Failed to submit pull")
+
+        # Hold lock — executor is blocked waiting for it
+        time.sleep(hold_seconds)
+
+        # Release lock — executor can now proceed
+        del write_handle
+
+        # Wait for copy to complete (should finish quickly after lock release)
+        client.wait_for_copy(copy_op_id)
+        elapsed = time.time() - start_time
+
+        result_queue.put({"success": True, "elapsed": elapsed})
+        client.disconnect()
+
+    except Exception as e:
+        import traceback
+
+        lock_acquired_event.set()
+        result_queue.put(
+            {"success": False, "error": str(e), "tb": traceback.format_exc()}
+        )
+
+
+@pytest.mark.gpu
+def test_client_write_lock_blocks_executor_write(infrastructure):
+    """
+    A client holding a write lock on a destination shard should block the
+    executor from acquiring its write lock for a pull into that shard.
+
+    Scenario:
+    1. Source client registers + writes source tensor
+    2. Same process: registers dest, acquires write lock, submits pull
+    3. Pull is submitted (non-blocking) while lock is held
+    4. After hold_seconds, lock is released — executor can proceed
+    5. wait_for_copy returns
+
+    We verify the total elapsed time from submit to completion >= hold_seconds.
+    """
+    client_endpoint = infrastructure["client_endpoint"]
+    dims_data = [("dim_0", 4, 0, 4), ("dim_1", 4, 0, 4)]
+    fill_value = 77.0
+    hold_seconds = 2.0
+
+    ctx = mp.get_context("spawn")
+    source_ready = ctx.Event()
+    lock_acquired = ctx.Event()
+    src_queue = ctx.Queue()
+    pull_queue = ctx.Queue()
+
+    # Step 1: Source registers and writes
+    src_proc = ctx.Process(
+        target=_source_register_and_write,
+        args=(
+            client_endpoint,
+            "block_src",
+            dims_data,
+            fill_value,
+            source_ready,
+            src_queue,
+        ),
+    )
+    src_proc.start()
+
+    # Step 2: Single process registers dest, holds write lock, submits pull,
+    # releases lock after hold_seconds, waits for completion.
+    # SubmitPull requires the same Client that registered the dest shard.
+    pull_proc = ctx.Process(
+        target=_register_lock_pull_release,
+        args=(
+            client_endpoint,
+            "block_src",
+            "block_dst",
+            dims_data,
+            hold_seconds,
+            source_ready,
+            lock_acquired,
+            pull_queue,
+        ),
+    )
+    pull_proc.start()
+
+    pull_proc.join(timeout=30)
+    src_proc.terminate()
+    src_proc.join(timeout=3)
+
+    src_result = src_queue.get()
+    assert src_result["success"], f"Source failed: {src_result.get('error')}"
+
+    pull_result = pull_queue.get()
+    assert pull_result["success"], f"Pull failed: {pull_result.get('error')}"
+
+    # The pull should have been delayed by the write lock
+    elapsed = pull_result["elapsed"]
+    assert elapsed >= hold_seconds * 0.8, (
+        f"Pull completed in {elapsed:.2f}s, expected >= {hold_seconds * 0.8:.2f}s "
+        f"(lock was held for {hold_seconds}s)"
+    )
+
+
+@pytest.mark.gpu
+def test_concurrent_pulls_same_source(infrastructure):
+    """
+    Multiple concurrent pulls from the same source should succeed.
+
+    The executor acquires read locks on the source shard. Since read locks
+    are shared (sharable), multiple concurrent executions reading the same
+    source should not block each other.
+    """
+    client_endpoint = infrastructure["client_endpoint"]
+    dims_data = [("dim_0", 4, 0, 4), ("dim_1", 8, 0, 8)]
+    fill_value = 55.0
+    num_dest_clients = 3
+
+    ctx = mp.get_context("spawn")
+    source_ready = ctx.Event()
+    src_queue = ctx.Queue()
+
+    # Source registers and writes
+    src_proc = ctx.Process(
+        target=_source_register_and_write,
+        args=(
+            client_endpoint,
+            "concurrent_src",
+            dims_data,
+            fill_value,
+            source_ready,
+            src_queue,
+        ),
+    )
+    src_proc.start()
+    assert source_ready.wait(timeout=15), "Source failed to start"
+
+    # Launch multiple destination clients concurrently
+    dst_procs = []
+    dst_queues = []
+    for i in range(num_dest_clients):
+        q = ctx.Queue()
+        dst_queues.append(q)
+        proc = ctx.Process(
+            target=_dest_pull_and_verify,
+            args=(
+                client_endpoint,
+                "concurrent_src",
+                f"concurrent_dst_{i}",
+                dims_data,
+                fill_value,
+                source_ready,
+                q,
+            ),
+        )
+        proc.start()
+        dst_procs.append(proc)
+
+    # Wait for all to complete
+    for proc in dst_procs:
+        proc.join(timeout=30)
+
+    src_proc.terminate()
+    src_proc.join(timeout=3)
+
+    # Verify all pulls succeeded with correct data
+    for i, q in enumerate(dst_queues):
+        result = q.get()
+        assert result["success"], f"Dest {i} failed: {result.get('error')}"
+        assert result[
+            "matches"
+        ], f"Dest {i} data mismatch: expected {fill_value}, got {result['actual']}"
+
+
+@pytest.mark.gpu
+def test_sequential_pulls_lock_cycle(infrastructure):
+    """
+    Sequential pull operations should correctly acquire and release locks
+    each time. After each pull, the destination should be freely accessible.
+    """
+    from setu._commons.datatypes import Device, TensorDimSpec, TensorShardSpec
+    from setu.client import Client
+
+    client_endpoint = infrastructure["client_endpoint"]
+    dims_data = [("dim_0", 4, 0, 4), ("dim_1", 4, 0, 4)]
+
+    ctx = mp.get_context("spawn")
+
+    for iteration, fill_value in enumerate([10.0, 20.0, 30.0]):
+        src_name = f"seq_src_{iteration}"
+        dst_name = f"seq_dst_{iteration}"
+
+        source_ready = ctx.Event()
+        src_queue = ctx.Queue()
+        dst_queue = ctx.Queue()
+
+        src_proc = ctx.Process(
+            target=_source_register_and_write,
+            args=(
+                client_endpoint,
+                src_name,
+                dims_data,
+                fill_value,
+                source_ready,
+                src_queue,
+            ),
+        )
+        src_proc.start()
+
+        dst_proc = ctx.Process(
+            target=_dest_pull_and_verify,
+            args=(
+                client_endpoint,
+                src_name,
+                dst_name,
+                dims_data,
+                fill_value,
+                source_ready,
+                dst_queue,
+            ),
+        )
+        dst_proc.start()
+
+        dst_proc.join(timeout=30)
+        src_proc.terminate()
+        src_proc.join(timeout=3)
+
+        dst_result = dst_queue.get()
+        assert dst_result[
+            "success"
+        ], f"Iteration {iteration} pull failed: {dst_result.get('error')}"
+        assert dst_result["matches"], (
+            f"Iteration {iteration} data mismatch: "
+            f"expected {fill_value}, got {dst_result['actual']}"
+        )
+
+        # After pull, verify we can freely read/write via a new client
+        client = Client(client_endpoint)
+        device = Device(torch_device=torch.device("cuda:0"))
+        dims = [TensorDimSpec(n, s, st, e) for n, s, st, e in dims_data]
+        shard_spec = TensorShardSpec(
+            name=dst_name, dims=dims, dtype=torch.float32, device=device
+        )
+        shard_ref = client.register_tensor_shard(shard_spec)
+        if shard_ref is not None:
+            with client.read(shard_ref) as tensor:
+                assert (
+                    tensor is not None
+                ), f"Iteration {iteration}: should read after executor lock release"
+        client.disconnect()
+
+
+if __name__ == "__main__":
+    mp.set_start_method("spawn")
+    pytest.main([__file__, "-v", "--gpu"])


### PR DESCRIPTION
## Summary
- Add ShardAccess tracking to LLC instructions (Copy, Send, Receive, InitComm, UseComm, Barrier)
- Each instruction declares which shards it reads/writes via ShardAccessMap
- NodeAgent Executor acquires sorted file locks (ProgramLockGuard) before dispatching programs to workers