### PR TITLE
Add --blocking/--no-blocking flag to bench for fair nccl-test comparison

### DIFF
--- a/setu/bench/__main__.py
+++ b/setu/bench/__main__.py
@@ -164,6 +164,14 @@ def parse_args():
         help="Timeout in seconds for the experiment (default: 600).",
     )
     parser.add_argument(
+        "--blocking",
+        action=argparse.BooleanOptionalAction,
+        default=True,
+        help="Block after each copy round (default: True). "
+        "--no-blocking queues all rounds then syncs once, "
+        "amortising control-plane overhead like nccl-test -C 0.",
+    )
+    parser.add_argument(
         "--enable-metrics",
         action="store_true",
         default=False,
@@ -367,8 +375,9 @@ def main():
     )
     print(f"Src: {args.src or 'all of node 0'}")
     print(f"Dst: {args.dst or 'all of node 0'}")
+    blocking_str = "blocking" if args.blocking else "non-blocking"
     print(
-        f"Mode: {copy_mode.value}, rounds: {args.rounds} + {args.warmup_rounds} warmup"
+        f"Mode: {copy_mode.value}, rounds: {args.rounds} + {args.warmup_rounds} warmup, {blocking_str}"
     )
     print()
 
@@ -385,6 +394,7 @@ def main():
             timeout=args.timeout,
             n_copy_rounds=args.rounds,
             n_warmup_rounds=args.warmup_rounds,
+            blocking=args.blocking,
             metrics_http_url=cluster_info.metrics_http_url,
         )
         print(result.pretty_print())

--- a/setu/bench/result.py
+++ b/setu/bench/result.py
@@ -83,6 +83,7 @@ class ExperimentResult:
     shard_bytes: List[int] = field(default_factory=list)
     n_warmup_rounds: int = 0
     warmup_round_elapsed_s: List[float] = field(default_factory=list)
+    blocking: bool = True
     metrics_reports: Optional[Dict] = None
 
     def pretty_print(self) -> str:
@@ -112,6 +113,7 @@ class ExperimentResult:
         header.add_row("Result", Text(status_text, style=status_style))
         if self.copy_mode is not None:
             header.add_row("Copy mode", self.copy_mode.value.upper())
+        header.add_row("Blocking", "yes" if self.blocking else "no")
         header.add_row("E2E wall time", _format_time(self.elapsed_s))
         if total_bytes:
             header.add_row("Total data", _format_size(total_bytes))
@@ -153,10 +155,11 @@ class ExperimentResult:
 
         # -- Per-round summary --
         if self.round_elapsed_s:
-            rt = Table(
-                title="Round Summary (barrier-to-barrier, max across clients)",
-                show_lines=False,
-            )
+            if self.blocking:
+                round_table_title = "Round Summary (blocking, max across clients)"
+            else:
+                round_table_title = "Round Summary (non-blocking, amortized throughput)"
+            rt = Table(title=round_table_title, show_lines=False)
             rt.add_column("Round", justify="right")
             rt.add_column("Latency", justify="right")
             rt.add_column("Agg BW", justify="right")

--- a/setu/bench/runner.py
+++ b/setu/bench/runner.py
@@ -40,7 +40,9 @@ def _source_body(
     copy_mode,
     dst_name,
     selections,
+    n_warmup_rounds,
     n_copy_rounds,
+    blocking,
     hints=None,
 ):
     """Register a source shard, fill with init_value, then run N copy rounds.
@@ -89,37 +91,61 @@ def _source_body(
 
     barrier.wait()  # all registered
 
-    round_times = []
-    for round_i in range(n_copy_rounds):
+    def _submit_source_copy():
+        src_selection = client.select(shard_spec.name)
+        dst_selection = client.select(dst_name)
+        if selections is not None:
+            for dim_name, indices in selections.items():
+                src_selection = src_selection.where(dim_name, indices)
+                dst_selection = dst_selection.where(dim_name, indices)
+        op_id = client.copy(src_selection, dst_selection, hints=hints)
+        assert op_id is not None, "Copy operation returned None"
+        return op_id
+
+    # Warmup rounds — always blocking so NCCL communicators are fully initialised
+    # before the timed section.
+    warmup_times = []
+    for round_i in range(n_warmup_rounds):
         barrier.wait()  # round start
-
         t_round = time.monotonic()
-
         if copy_mode == CopyMode.COPY:
-            src_selection = client.select(shard_spec.name)
-            dst_selection = client.select(dst_name)
-
-            if selections is not None:
-                for dim_name, indices in selections.items():
-                    src_selection = src_selection.where(dim_name, indices)
-                    dst_selection = dst_selection.where(dim_name, indices)
-
-            copy_op_id = client.copy(src_selection, dst_selection, hints=hints)
-            assert copy_op_id is not None, "Copy operation returned None"
-            logger.debug(
-                "%s: round %d, submitted copy op %s, waiting...",
-                tag,
-                round_i,
-                copy_op_id,
-            )
-            client.wait(copy_op_id)
-
+            client.wait(_submit_source_copy())
         elapsed = time.monotonic() - t_round
-
         barrier.wait()  # round end
+        warmup_times.append(elapsed)
+        logger.debug("%s: warmup %d complete in %.3fs", tag, round_i, elapsed)
 
-        round_times.append(elapsed)
-        logger.debug("%s: round %d complete in %.3fs", tag, round_i, elapsed)
+    # Measured rounds.
+    round_times = []
+    if blocking:
+        for round_i in range(n_copy_rounds):
+            barrier.wait()  # round start
+            t_round = time.monotonic()
+            if copy_mode == CopyMode.COPY:
+                op_id = _submit_source_copy()
+                logger.debug("%s: round %d, submitted copy op %s, waiting...", tag, round_i, op_id)
+                client.wait(op_id)
+            elapsed = time.monotonic() - t_round
+            barrier.wait()  # round end
+            round_times.append(elapsed)
+            logger.debug("%s: round %d complete in %.3fs", tag, round_i, elapsed)
+    else:
+        # Non-blocking: submit all copies, then wait for all.  Mirrors nccl-test
+        # -C 0 behaviour where ops are queued and synced once at the end.
+        barrier.wait()  # all ranks start together
+        t_all = time.monotonic()
+        op_ids = []
+        if copy_mode == CopyMode.COPY:
+            for round_i in range(n_copy_rounds):
+                op_ids.append(_submit_source_copy())
+                logger.debug("%s: round %d, submitted (non-blocking)", tag, round_i)
+        for op_id in op_ids:
+            client.wait(op_id)
+        total_elapsed = time.monotonic() - t_all
+        barrier.wait()  # all ranks done
+        per_round = total_elapsed / n_copy_rounds if n_copy_rounds > 0 else 0.0
+        round_times = [per_round] * n_copy_rounds
+        logger.debug("%s: non-blocking batch complete in %.3fs (%.3f/round)", tag, total_elapsed, per_round)
 
     logger.debug("%s: total body time=%.3fs", tag, time.monotonic() - t_body)
 
@@ -128,7 +154,7 @@ def _source_body(
         "success": True,
         "shard_name": shard_spec.name,
         "device": str(shard_spec.device.torch_device),
-        "round_elapsed_s": round_times,
+        "round_elapsed_s": warmup_times + round_times,
     }
 
 
@@ -141,7 +167,9 @@ def _dest_body(
     copy_mode,
     value_to_match,
     selections,
+    n_warmup_rounds,
     n_copy_rounds,
+    blocking,
     hints=None,
 ):
     """Register a dest shard, then run N copy rounds with verification on the last.
@@ -171,41 +199,57 @@ def _dest_body(
 
     barrier.wait()  # all registered
 
-    round_times = []
-    for round_i in range(n_copy_rounds):
-        barrier.wait()  # round start
-
-        t_round = time.monotonic()
-
+    def _submit_dest_copy():
         src_selection = client.select(src_name)
         dst_selection = client.select(shard_spec.name)
-
         if selections is not None:
             for dim_name, indices in selections.items():
                 src_selection = src_selection.where(dim_name, indices)
                 dst_selection = dst_selection.where(dim_name, indices)
-
         if copy_mode == CopyMode.PULL:
-            copy_op_id = client.pull(src_selection, dst_selection, hints=hints)
+            op_id = client.pull(src_selection, dst_selection, hints=hints)
         else:
-            copy_op_id = client.copy(src_selection, dst_selection, hints=hints)
+            op_id = client.copy(src_selection, dst_selection, hints=hints)
+        assert op_id is not None, "Copy operation returned None"
+        return op_id
 
-        assert copy_op_id is not None, "Copy operation returned None"
-        logger.debug(
-            "%s: round %d, submit %s op %s, waiting...",
-            tag,
-            round_i,
-            copy_mode.value,
-            copy_op_id,
-        )
-        client.wait(copy_op_id)
-
+    # Warmup rounds — always blocking.
+    warmup_times = []
+    for round_i in range(n_warmup_rounds):
+        barrier.wait()  # round start
+        t_round = time.monotonic()
+        client.wait(_submit_dest_copy())
         elapsed = time.monotonic() - t_round
-
         barrier.wait()  # round end
+        warmup_times.append(elapsed)
+        logger.debug("%s: warmup %d complete in %.3fs", tag, round_i, elapsed)
 
-        round_times.append(elapsed)
-        logger.debug("%s: round %d complete in %.3fs", tag, round_i, elapsed)
+    # Measured rounds.
+    round_times = []
+    if blocking:
+        for round_i in range(n_copy_rounds):
+            barrier.wait()  # round start
+            t_round = time.monotonic()
+            op_id = _submit_dest_copy()
+            logger.debug("%s: round %d, submit %s op %s, waiting...", tag, round_i, copy_mode.value, op_id)
+            client.wait(op_id)
+            elapsed = time.monotonic() - t_round
+            barrier.wait()  # round end
+            round_times.append(elapsed)
+            logger.debug("%s: round %d complete in %.3fs", tag, round_i, elapsed)
+    else:
+        # Non-blocking: queue all copies, sync once at the end.
+        barrier.wait()  # all ranks start together
+        t_all = time.monotonic()
+        op_ids = [_submit_dest_copy() for round_i in range(n_copy_rounds)]
+        logger.debug("%s: submitted %d %s ops (non-blocking)", tag, n_copy_rounds, copy_mode.value)
+        for op_id in op_ids:
+            client.wait(op_id)
+        total_elapsed = time.monotonic() - t_all
+        barrier.wait()  # all ranks done
+        per_round = total_elapsed / n_copy_rounds if n_copy_rounds > 0 else 0.0
+        round_times = [per_round] * n_copy_rounds
+        logger.debug("%s: non-blocking batch complete in %.3fs (%.3f/round)", tag, total_elapsed, per_round)
 
     # Verify values after all rounds complete
     t_read = time.monotonic()
@@ -228,7 +272,7 @@ def _dest_body(
         "success": True,
         "shard_name": shard_spec.name,
         "device": str(shard_spec.device.torch_device),
-        "round_elapsed_s": round_times,
+        "round_elapsed_s": warmup_times + round_times,
         "expected_value": value_to_match,
         "actual_value": actual_value,
         "values_match": values_match,
@@ -295,6 +339,7 @@ def run_experiment(
     timeout: float = 60.0,
     n_copy_rounds: int = 1,
     n_warmup_rounds: int = 0,
+    blocking: bool = True,
     metrics_http_url: str = "",
     hints: Optional[List] = None,
 ) -> ExperimentResult:
@@ -324,9 +369,6 @@ def run_experiment(
     from setu.bench.backends import backend_for
 
     backend = backend_for(cluster_info)
-
-    # Bodies execute warmup + measured rounds; we strip warmup from results.
-    n_total_rounds = n_warmup_rounds + n_copy_rounds
 
     src_shards = src.shards
     dst_shards = dst.shards
@@ -397,7 +439,9 @@ def run_experiment(
                 copy_mode=copy_mode,
                 dst_name=dst.name,
                 selections=selections,
-                n_copy_rounds=n_total_rounds,
+                n_warmup_rounds=n_warmup_rounds,
+                n_copy_rounds=n_copy_rounds,
+                blocking=blocking,
                 hints=hints,
             )
             handles.append(backend.spawn_client(cluster_info, participant, body))
@@ -413,7 +457,9 @@ def run_experiment(
                 copy_mode=copy_mode,
                 value_to_match=init_value,
                 selections=selections,
-                n_copy_rounds=n_total_rounds,
+                n_warmup_rounds=n_warmup_rounds,
+                n_copy_rounds=n_copy_rounds,
+                blocking=blocking,
                 hints=hints,
             )
             handles.append(backend.spawn_client(cluster_info, participant, body))
@@ -516,5 +562,6 @@ def run_experiment(
         shard_bytes=shard_bytes,
         n_warmup_rounds=n_warmup_rounds,
         warmup_round_elapsed_s=warmup_round_elapsed_s,
+        blocking=blocking,
         metrics_reports=metrics_reports,
     )


### PR DESCRIPTION
Mirrors nccl-test sendrecv_perf -z semantics: with --no-blocking, all N copy rounds are submitted back-to-back and synced once at the end, amortising the per-copy ZMQ control-plane overhead. Warmup rounds remain always-blocking to ensure NCCL communicators are fully initialised before the timed section.

The reported BW in non-blocking mode reflects steady-state throughput, making it directly comparable to nccl-test algbw numbers.